### PR TITLE
Redesign portfolio in Windows 2000 style

### DIFF
--- a/src/app/components/PageTabs.tsx
+++ b/src/app/components/PageTabs.tsx
@@ -1,4 +1,4 @@
-﻿"use client"
+"use client"
 
 import React, { ReactNode } from "react"
 
@@ -25,8 +25,11 @@ const PageTabs = ({ tabs, activeId, onChange, align = "center" }: PageTabsProps)
       : "justify-start"
 
   return (
-    <div className="inline-flex max-w-full bg-[#1e1e1e] border border-[#333333] rounded-xl py-3 px-4">
-      <div className={`flex flex-wrap gap-3 ${justifyClass}`}>
+    <div
+      className="inline-flex max-w-full"
+      style={{ fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif' }}
+    >
+      <div className={`flex flex-wrap gap-1 ${justifyClass}`}>
         {tabs.map((tab) => {
           const isActive = activeId === tab.id
           const nextValue = tab.tabValue === undefined ? tab.id : tab.tabValue
@@ -38,13 +41,27 @@ const PageTabs = ({ tabs, activeId, onChange, align = "center" }: PageTabsProps)
               onClick={() => onChange(nextValue)}
               aria-pressed={isActive}
               aria-label={tab.label}
-              className={`group inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg transition-all duration-200 border text-sm font-medium whitespace-nowrap ${
-                isActive
-                  ? "bg-gradient-to-r from-red-600 to-red-500 text-white shadow-lg shadow-red-600/40 cursor-pointer border-transparent"
-                  : "bg-[#2a2a2a] text-gray-300 hover:bg-[#333333] hover:text-[#dc2626] hover:border-red-600 hover:shadow-lg hover:shadow-red-600/30 hover:scale-105 cursor-pointer border-transparent"
-              }`}
+              className="inline-flex items-center justify-center gap-1.5 whitespace-nowrap"
+              style={{
+                padding: "3px 10px",
+                fontSize: "11px",
+                fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+                fontWeight: isActive ? "bold" : "normal",
+                background: isActive ? "#d4d0c8" : "#c0bdb4",
+                color: "#000000",
+                borderTopColor: isActive ? "#ffffff" : "#c8c5bc",
+                borderLeftColor: isActive ? "#ffffff" : "#c8c5bc",
+                borderRightColor: isActive ? "#404040" : "#808080",
+                borderBottomColor: isActive ? (isActive ? "transparent" : "#404040") : "#808080",
+                borderStyle: "solid",
+                borderWidth: "1px",
+                cursor: isActive ? "default" : "pointer",
+                marginBottom: isActive ? "-1px" : "0",
+                position: "relative",
+                zIndex: isActive ? 1 : 0,
+              }}
             >
-              {tab.icon && <span className="text-lg">{tab.icon}</span>}
+              {tab.icon && <span style={{ fontSize: "11px" }}>{tab.icon}</span>}
               <span>{tab.label}</span>
             </button>
           )

--- a/src/app/components/SearchFilterBar.tsx
+++ b/src/app/components/SearchFilterBar.tsx
@@ -99,59 +99,98 @@ export default function SearchFilterBar({
     }
   }, [showFilterMenu, setShowFilterMenu]);
 
+  const win2kFont: React.CSSProperties = {
+    fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+    fontSize: "11px",
+  }
+
   return (
-    <div className="bg-transparent p-4 rounded-lg mb-2">
+    <div className="mb-2" style={win2kFont}>
       {/* Search Bar with Buttons */}
-      <div className="relative mb-4">
+      <div className="relative mb-2 flex items-center gap-1">
         <input
           type="text"
           placeholder={placeholder}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-full p-4 pr-32 bg-[#1e1e1e] border border-[#333333] rounded-lg text-white focus:border-red-600 focus:outline-none transition-all hover:border-red-600/70 hover:shadow-lg hover:shadow-red-600/20 hover:scale-[1.01]"
+          style={{
+            ...win2kFont,
+            flex: 1,
+            padding: "3px 6px",
+            background: "#ffffff",
+            color: "#000000",
+            borderTop: "1px solid #808080",
+            borderLeft: "1px solid #808080",
+            borderRight: "1px solid #ffffff",
+            borderBottom: "1px solid #ffffff",
+            outline: "none",
+          }}
         />
         
-        {/* Filter & Sort Buttons Container */}
-        <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
-          {/* Filter Options Button - Shows Tags */}
-          <button
-            onClick={() => {
-              setShowTagsMenu(!showTagsMenu);
-              setShowFilterMenu(false);
-            }}
-            className={`group p-2 rounded-lg transition-all duration-200 hover:border-red-600/70 hover:shadow-lg hover:shadow-red-600/30 hover:scale-105 border border-transparent ${
-              showTagsMenu ? "text-[#dc2626]" : "text-gray-400 hover:text-gray-300"
-            }`}
-            title="Filter Options"
-          >
-            <FaFilter className={`w-5 h-5 transition-colors ${showTagsMenu ? "text-[#dc2626]" : "group-hover:text-[#dc2626]"}`} />
-          </button>
+        {/* Filter & Sort Buttons */}
+        <button
+          onClick={() => {
+            setShowTagsMenu(!showTagsMenu);
+            setShowFilterMenu(false);
+          }}
+          className="win-btn flex items-center gap-1"
+          style={{
+            ...win2kFont,
+            padding: "2px 6px",
+            minWidth: "auto",
+            background: showTagsMenu ? "#c0bdb4" : "#d4d0c8",
+            borderTopColor: showTagsMenu ? "#404040" : "#ffffff",
+            borderLeftColor: showTagsMenu ? "#404040" : "#ffffff",
+            borderRightColor: showTagsMenu ? "#ffffff" : "#404040",
+            borderBottomColor: showTagsMenu ? "#ffffff" : "#404040",
+          }}
+          title="Filter Options"
+        >
+          <FaFilter style={{ fontSize: "10px" }} />
+          <span>Filter</span>
+        </button>
 
-          {/* Sort Options Button - No wrapper needed */}
-          <button
-            ref={sortButtonRef}
-            onClick={() => {
-              setShowFilterMenu(!showFilterMenu);
-              setShowTagsMenu(false);
-            }}
-            className={`group p-2 rounded-lg transition-all duration-200 hover:border-red-600/70 hover:shadow-lg hover:shadow-red-600/30 hover:scale-105 border border-transparent focus:outline-none ${
-              showFilterMenu || isSortActive ? "text-[#dc2626]" : "text-gray-400 hover:text-gray-300"
-            }`}
-            title="Sort Options"
-          >
-            <FaSort className={`w-5 h-5 transition-colors ${showFilterMenu || isSortActive ? "text-[#dc2626]" : "group-hover:text-[#dc2626]"}`} />
-          </button>
-        </div>
+        <button
+          ref={sortButtonRef}
+          onClick={() => {
+            setShowFilterMenu(!showFilterMenu);
+            setShowTagsMenu(false);
+          }}
+          className="win-btn flex items-center gap-1"
+          style={{
+            ...win2kFont,
+            padding: "2px 6px",
+            minWidth: "auto",
+            background: showFilterMenu ? "#c0bdb4" : "#d4d0c8",
+            borderTopColor: showFilterMenu ? "#404040" : "#ffffff",
+            borderLeftColor: showFilterMenu ? "#404040" : "#ffffff",
+            borderRightColor: showFilterMenu ? "#ffffff" : "#404040",
+            borderBottomColor: showFilterMenu ? "#ffffff" : "#404040",
+          }}
+          title="Sort Options"
+        >
+          <FaSort style={{ fontSize: "10px" }} />
+          <span>Sort{isSortActive ? " *" : ""}</span>
+        </button>
       </div>
 
-      {/* Filter Tags - Animated Dropdown */}
+      {/* Filter Tags */}
       <div
         ref={tagsRef}
-        className={`transition-all duration-300 ease-in-out overflow-hidden ${
-          showTagsMenu ? "max-h-[500px] opacity-100 mb-4" : "max-h-0 opacity-0 pointer-events-none"
+        className={`transition-all duration-200 overflow-hidden ${
+          showTagsMenu ? "max-h-[400px] opacity-100 mb-2" : "max-h-0 opacity-0 pointer-events-none"
         }`}
       >
-        <div className="flex max-h-[220px] flex-wrap content-start gap-2 overflow-y-auto pr-1">
+        <div
+          className="flex max-h-[180px] flex-wrap content-start gap-1 overflow-y-auto p-2"
+          style={{
+            background: "#ffffff",
+            borderTop: "1px solid #808080",
+            borderLeft: "1px solid #808080",
+            borderRight: "1px solid #ffffff",
+            borderBottom: "1px solid #ffffff",
+          }}
+        >
           {selectedTag && (
             <button
               onClick={() => {
@@ -159,10 +198,20 @@ export default function SearchFilterBar({
                 setSearch("");
                 onFilterInteraction?.();
               }}
-              className="text-gray-400 hover:text-red-600 transition-colors hover:scale-110 transition-all duration-200 p-1"
+              className="flex items-center justify-center"
+              style={{
+                ...win2kFont,
+                background: "#d4d0c8",
+                borderTop: "1px solid #fff",
+                borderLeft: "1px solid #fff",
+                borderRight: "1px solid #404040",
+                borderBottom: "1px solid #404040",
+                padding: "1px 4px",
+                cursor: "pointer",
+              }}
               title="Clear filters"
             >
-              <IoMdClose className="w-5 h-5" />
+              <IoMdClose style={{ fontSize: "11px" }} />
             </button>
           )}
           {sortedTags.map((tag) => (
@@ -172,11 +221,17 @@ export default function SearchFilterBar({
                 setSelectedTag(selectedTag === tag ? null : tag);
                 onFilterInteraction?.();
               }}
-              className={`px-3 py-1 rounded-full text-sm transition-all duration-200 border border-transparent ${
-                selectedTag === tag
-                  ? "bg-red-600 text-white shadow-lg shadow-red-600/40"
-                  : "bg-[#3a3a3a] text-gray-300 hover:bg-[#444444] hover:scale-105 hover:shadow-lg hover:shadow-red-600/30 hover:border-red-600 hover:text-[#dc2626]"
-              }`}
+              style={{
+                ...win2kFont,
+                padding: "1px 6px",
+                background: selectedTag === tag ? "#000080" : "#d4d0c8",
+                color: selectedTag === tag ? "#ffffff" : "#000000",
+                borderTop: "1px solid #fff",
+                borderLeft: "1px solid #fff",
+                borderRight: "1px solid #404040",
+                borderBottom: "1px solid #404040",
+                cursor: "pointer",
+              }}
             >
               {tag.toUpperCase()}
             </button>
@@ -184,14 +239,23 @@ export default function SearchFilterBar({
         </div>
       </div>
 
-      {/* Sort Dropdown Portal - Rendered outside component hierarchy to escape z-index constraints */}
+      {/* Sort Dropdown Portal */}
       {mounted && showFilterMenu && createPortal(
         <div 
           ref={dropdownRef}
-          className="fixed z-[9999] bg-[#1e1e1e] border border-[#333333] rounded-lg shadow-lg min-w-[200px] animate-[popIn_0.2s_ease-out]"
+          className="fixed z-[9999] animate-[popIn_0.15s_ease-out]"
           style={{
             top: `${dropdownPosition.top}px`,
             left: `${dropdownPosition.left}px`,
+            background: "#d4d0c8",
+            borderTop: "1px solid #ffffff",
+            borderLeft: "1px solid #ffffff",
+            borderRight: "1px solid #404040",
+            borderBottom: "1px solid #404040",
+            boxShadow: "2px 2px 4px rgba(0,0,0,0.4)",
+            minWidth: "160px",
+            padding: "2px",
+            ...win2kFont,
           }}
         >
           {sortOptions.map((option) => (
@@ -202,11 +266,27 @@ export default function SearchFilterBar({
                 setShowFilterMenu(false);
                 onFilterInteraction?.();
               }}
-              className={`w-full text-left px-4 py-2 transition-colors first:rounded-t-lg last:rounded-b-lg ${
-                selectedSort === option.value
-                  ? "bg-red-600 text-white"
-                  : "text-gray-300 hover:bg-[#2a2a2a] hover:text-[#dc2626]"
-              }`}
+              className="w-full text-left"
+              style={{
+                padding: "3px 8px",
+                background: selectedSort === option.value ? "#000080" : "transparent",
+                color: selectedSort === option.value ? "#ffffff" : "#000000",
+                border: "none",
+                cursor: "default",
+                ...win2kFont,
+              }}
+              onMouseEnter={e => {
+                if (selectedSort !== option.value) {
+                  (e.currentTarget as HTMLButtonElement).style.background = "#000080"
+                  ;(e.currentTarget as HTMLButtonElement).style.color = "#ffffff"
+                }
+              }}
+              onMouseLeave={e => {
+                if (selectedSort !== option.value) {
+                  (e.currentTarget as HTMLButtonElement).style.background = "transparent"
+                  ;(e.currentTarget as HTMLButtonElement).style.color = "#000000"
+                }
+              }}
             >
               {option.label}
             </button>

--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -253,131 +253,169 @@ const Timeline: React.FC<TimelineProps> = ({
             allLinks.push(...item.links)
           }
 
+          const win2kFont: React.CSSProperties = {
+            fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+            fontSize: "11px",
+          }
+
           return (
             <div
               key={itemKey}
               onClick={handleCardClick}
-              className={`group relative z-0 hover:z-10 flex h-full min-h-[520px] self-stretch flex-col bg-[#151515] hover:bg-[#252525] p-6 rounded-none border border-[#333333] hover:border-red-600/50 transition-all duration-300 ease-out hover:scale-[1.02] hover:shadow-lg hover:shadow-red-600/30 ${
+              className={`group relative z-0 hover:z-10 flex h-full min-h-[420px] self-stretch flex-col transition-all duration-150 ${
                 isHorizontal ? "shrink-0 w-full snap-center" : "w-full"
-              } ${
-                 isNewItem ? "animate-fade-in-up border-red-600/30" : ""
-               } ${isDisappearing ? "animate-fade-out-down" : ""}`}
+              } ${isNewItem ? "animate-fade-in-up" : ""} ${isDisappearing ? "animate-fade-out-down" : ""}`}
+              style={{
+                background: "#d4d0c8",
+                borderTop: "1px solid #ffffff",
+                borderLeft: "1px solid #ffffff",
+                borderRight: "1px solid #404040",
+                borderBottom: "1px solid #404040",
+                padding: "0",
+                ...win2kFont,
+              }}
             >
-              {/* Title */}
-              <h3 className="text-2xl font-semibold text-white mb-2 group-hover:text-[#dc2626] transition-colors duration-300">
-                {item.institution || item.name}
-              </h3>
-
-              {/* Dates */}
-              <div className="flex flex-wrap items-center gap-3 mb-4 text-gray-400">
-                <span>
-                  {item.startDate} to {item.endDate}
-                </span>
-                {item.location && (
-                  <>
-                    <span className="text-gray-600">•</span>
-                    <span
-                      onClick={onTagClick ? () => onTagClick(item.location ?? "") : undefined}
-                      data-skip-card-scroll="true"
-                      className={`${badgeBaseClass} ${getLocationTagClass(item.location)} ${onTagClick ? clickableBadgeClass : ""}`}
-                    >
-                      {item.location}
-                    </span>
-                  </>
-                )}
-                {item.language && (
-                  <>
-                    <span className="text-gray-600">•</span>
-                    <span
-                      onClick={onTagClick ? () => onTagClick(item.language ?? "") : undefined}
-                      data-skip-card-scroll="true"
-                      className={`${badgeBaseClass} ${getLanguageTagClass(item.language)} ${onTagClick ? clickableBadgeClass : ""}`}
-                    >
-                      {item.language}
-                    </span>
-                  </>
-                )}
+              {/* Win2K title bar */}
+              <div className="win-titlebar" style={{ fontSize: "11px" }}>
+                <span className="truncate">{item.institution || item.name}</span>
               </div>
 
-              {/* Highlights */}
-              {item.highlights && item.highlights.length > 0 && (
-                <ul className="list-disc list-inside mb-4 text-gray-400 space-y-1">
-                  {item.highlights.map((hl, i) => (
-                    <li key={i}>{hl}</li>
-                  ))}
-                </ul>
-              )}
+              <div style={{ padding: "8px" }} className="flex flex-col flex-1">
+                {/* Title */}
+                <h3 style={{ fontSize: "13px", fontWeight: "bold", color: "#000080", marginBottom: "4px" }}>
+                  {item.institution || item.name}
+                </h3>
 
-              {/* Summary/Description */}
-              <p className="text-gray-300 mb-4">{item.summary}</p>
-
-              {/* Images with Carousel */}
-              {item.images && item.images.length > 0 && (
-                <ImageCarousel
-                  images={item.images}
-                  title={item.institution || item.name || "Timeline Item"}
-                />
-              )}
-
-              {/* Topics/Tags */}
-              {(() => {
-                const displayTags = Array.from(
-                  new Set([...(item.topics ?? []), ...(item.tags ?? [])])
-                )
-                if (displayTags.length === 0) return null
-                const tagClassName = onTagClick
-                  ? "bg-[#3a3a3a] text-gray-300 text-xs px-3 py-1 rounded-full whitespace-nowrap transition-all duration-200 border border-transparent hover:bg-[#444444] hover:scale-105 hover:shadow-lg hover:shadow-red-600/30 hover:border-red-600 hover:text-[#dc2626] cursor-pointer active:scale-95"
-                  : "bg-[#333333] text-gray-300 text-xs px-2 py-1 rounded-full"
-
-                return (
-                  <div className="flex flex-wrap gap-1.5 mb-4">
-                    {displayTags.map((tag) => (
+                {/* Dates */}
+                <div className="flex flex-wrap items-center gap-2 mb-3" style={{ fontSize: "10px", color: "#444444" }}>
+                  <span>{item.startDate} to {item.endDate}</span>
+                  {item.location && (
+                    <>
+                      <span style={{ color: "#808080" }}>•</span>
                       <span
-                        key={tag}
-                        onClick={onTagClick ? () => onTagClick(tag) : undefined}
+                        onClick={onTagClick ? () => onTagClick(item.location ?? "") : undefined}
                         data-skip-card-scroll="true"
-                        className={tagClassName}
+                        style={{
+                          padding: "1px 5px",
+                          background: "#000080",
+                          color: "#ffffff",
+                          fontSize: "9px",
+                          cursor: onTagClick ? "pointer" : "default",
+                        }}
                       >
-                        {tag.toUpperCase()}
+                        {item.location}
                       </span>
-                    ))}
-                  </div>
-                )
-              })()}
-
-              {/* Links */}
-              {allLinks.length > 0 && (
-                <div className="flex flex-wrap gap-3 mb-4">
-                  {allLinks.map((link, i) => {
-                    const LinkIcon = link.icon ? linkIconMap[link.icon] : FaExternalLinkAlt
-                    const isProjectLink = (item.type ?? type) === "project"
-                    return (
-                      <TooltipWrapper key={i} label={link.url}>
-                        {isProjectLink ? (
-                          <button
-                            type="button"
-                            onClick={() => handleExternalClick(link.url, true)}
-                            className="inline-flex items-center gap-2 bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-white px-4 py-2 rounded-lg transition-all duration-200 ease-out hover:scale-105 active:scale-95"
-                          >
-                            {link.label}
-                            <LinkIcon className="text-sm" />
-                          </button>
-                        ) : (
-                          <a
-                            href={link.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-2 bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-white px-4 py-2 rounded-lg transition-all duration-200 ease-out hover:scale-105 active:scale-95"
-                          >
-                            {link.label}
-                            <LinkIcon className="text-sm" />
-                          </a>
-                        )}
-                      </TooltipWrapper>
-                    )
-                  })}
+                    </>
+                  )}
+                  {item.language && (
+                    <>
+                      <span style={{ color: "#808080" }}>•</span>
+                      <span
+                        onClick={onTagClick ? () => onTagClick(item.language ?? "") : undefined}
+                        data-skip-card-scroll="true"
+                        style={{
+                          padding: "1px 5px",
+                          background: "#808000",
+                          color: "#ffffff",
+                          fontSize: "9px",
+                          cursor: onTagClick ? "pointer" : "default",
+                        }}
+                      >
+                        {item.language}
+                      </span>
+                    </>
+                  )}
                 </div>
-              )}
+
+                {/* Highlights */}
+                {item.highlights && item.highlights.length > 0 && (
+                  <ul className="list-disc list-inside mb-3" style={{ fontSize: "11px", color: "#000000" }}>
+                    {item.highlights.map((hl, i) => (
+                      <li key={i} style={{ marginBottom: "2px" }}>{hl}</li>
+                    ))}
+                  </ul>
+                )}
+
+                {/* Summary/Description */}
+                <p className="mb-3" style={{ fontSize: "11px", color: "#222222" }}>{item.summary}</p>
+
+                {/* Images with Carousel */}
+                {item.images && item.images.length > 0 && (
+                  <ImageCarousel
+                    images={item.images}
+                    title={item.institution || item.name || "Timeline Item"}
+                  />
+                )}
+
+                {/* Topics/Tags */}
+                {(() => {
+                  const displayTags = Array.from(
+                    new Set([...(item.topics ?? []), ...(item.tags ?? [])])
+                  )
+                  if (displayTags.length === 0) return null
+
+                  return (
+                    <div className="flex flex-wrap gap-1 mb-3">
+                      {displayTags.map((tag) => (
+                        <span
+                          key={tag}
+                          onClick={onTagClick ? () => onTagClick(tag) : undefined}
+                          data-skip-card-scroll="true"
+                          style={{
+                            padding: "1px 5px",
+                            fontSize: "9px",
+                            background: "#c0bdb4",
+                            color: "#000000",
+                            borderTop: "1px solid #808080",
+                            borderLeft: "1px solid #808080",
+                            borderRight: "1px solid #ffffff",
+                            borderBottom: "1px solid #ffffff",
+                            cursor: onTagClick ? "pointer" : "default",
+                          }}
+                        >
+                          {tag.toUpperCase()}
+                        </span>
+                      ))}
+                    </div>
+                  )
+                })()}
+
+                {/* Links */}
+                {allLinks.length > 0 && (
+                  <div className="flex flex-wrap gap-2 mt-auto pt-2">
+                    {allLinks.map((link, i) => {
+                      const LinkIcon = link.icon ? linkIconMap[link.icon] : FaExternalLinkAlt
+                      const isProjectLink = (item.type ?? type) === "project"
+                      return (
+                        <TooltipWrapper key={i} label={link.url}>
+                          {isProjectLink ? (
+                            <button
+                              type="button"
+                              onClick={() => handleExternalClick(link.url, true)}
+                              className="win-btn inline-flex items-center gap-1"
+                              style={{ fontSize: "10px", padding: "2px 8px" }}
+                            >
+                              <LinkIcon style={{ fontSize: "10px" }} />
+                              {link.label}
+                            </button>
+                          ) : (
+                            <a
+                              href={link.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="win-btn inline-flex items-center gap-1"
+                              style={{ fontSize: "10px", padding: "2px 8px", textDecoration: "none", color: "#000000" }}
+                            >
+                              <LinkIcon style={{ fontSize: "10px" }} />
+                              {link.label}
+                            </a>
+                          )}
+                        </TooltipWrapper>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
             </div>
           )
         })}

--- a/src/app/components/ToolTipWrapper.tsx
+++ b/src/app/components/ToolTipWrapper.tsx
@@ -206,6 +206,16 @@ const TooltipWrapper = ({ label, children, url, imageUrl, fullWidth = false }: P
     updatePopupPosition()
   }, [updatePopupPosition])
 
+  const win2kTooltipStyle: React.CSSProperties = {
+    background: "#d4d0c8",
+    borderTop: "1px solid #ffffff",
+    borderLeft: "1px solid #ffffff",
+    borderRight: "1px solid #404040",
+    borderBottom: "1px solid #404040",
+    boxShadow: "2px 2px 4px rgba(0,0,0,0.4)",
+    fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+  }
+
   const pdfTooltip =
     canPreviewPdf && (visible || isClosing) && typeof document !== "undefined"
       ? ReactDOM.createPortal(
@@ -213,29 +223,32 @@ const TooltipWrapper = ({ label, children, url, imageUrl, fullWidth = false }: P
             ref={popupRef}
             role="tooltip"
             aria-label={label}
-            className={`fixed z-[9999] w-[260px] max-w-[90vw] overflow-hidden rounded-xl border border-[#333333] bg-[#1e1e1e] shadow-2xl shadow-black/50 ${
+            className={`fixed z-[9999] w-[260px] max-w-[90vw] overflow-hidden ${
               isClosing ? "animate-fade-out-down" : "animate-fade-in-up"
             }`}
-            style={
-              popupPosition
+            style={{
+              ...(popupPosition
                 ? { left: popupPosition.left, top: popupPosition.top }
-                : { visibility: "hidden", left: 0, top: 0 }
-            }
+                : { visibility: "hidden", left: 0, top: 0 }),
+              ...win2kTooltipStyle,
+            }}
           >
-            <div className="border-b border-[#333333] px-3 pb-1.5 pt-2">
-              <span className="text-xs font-bold uppercase tracking-wider bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
-                {label}
-              </span>
+            <div className="win-titlebar" style={{ fontSize: "10px", padding: "2px 6px" }}>
+              <span className="truncate">{label}</span>
             </div>
-            <div className="p-3 pt-2">
-              <div className="relative h-[260px] w-full overflow-hidden rounded-lg border border-[#333333] bg-[#111111]">
+            <div style={{ padding: "6px" }}>
+              <div className="relative h-[260px] w-full overflow-hidden" style={{
+                borderTop: "1px solid #808080", borderLeft: "1px solid #808080",
+                borderRight: "1px solid #ffffff", borderBottom: "1px solid #ffffff",
+                background: "#ffffff",
+              }}>
                 {thumbnailLoading && (
-                  <div className="absolute inset-0 flex items-center justify-center bg-[#111111]">
-                    <Loader2 className="h-6 w-6 animate-spin text-white/70" />
+                  <div className="absolute inset-0 flex items-center justify-center" style={{ background: "#ffffff" }}>
+                    <Loader2 className="h-6 w-6 animate-spin" style={{ color: "#000080" }} />
                   </div>
                 )}
                 {thumbnailError ? (
-                  <div className="absolute inset-0 flex items-center justify-center px-3 text-center text-xs text-white/70">
+                  <div className="absolute inset-0 flex items-center justify-center px-3 text-center" style={{ fontSize: "10px", color: "#444444" }}>
                     Unable to generate preview
                   </div>
                 ) : (
@@ -247,10 +260,10 @@ const TooltipWrapper = ({ label, children, url, imageUrl, fullWidth = false }: P
                     onError={handleThumbnailError}
                   />
                 )}
-                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-2">
-                  <div className="flex items-center justify-between text-xs text-white">
+                <div className="absolute inset-x-0 bottom-0 p-1" style={{ background: "#d4d0c8", borderTop: "1px solid #808080" }}>
+                  <div className="flex items-center justify-between" style={{ fontSize: "9px", color: "#000000" }}>
                     <span className="truncate max-w-[160px]">PDF Document</span>
-                    <span className="text-white/70">Preview</span>
+                    <span style={{ color: "#444444" }}>Preview</span>
                   </div>
                 </div>
               </div>
@@ -267,29 +280,33 @@ const TooltipWrapper = ({ label, children, url, imageUrl, fullWidth = false }: P
             ref={popupRef}
             role="tooltip"
             aria-label={label}
-            className={`fixed z-[9999] w-[280px] max-w-[90vw] overflow-hidden rounded-xl border border-[#333333] bg-[#1e1e1e] shadow-2xl shadow-black/50 ${
+            className={`fixed z-[9999] w-[280px] max-w-[90vw] overflow-hidden ${
               isClosing ? "animate-fade-out-down" : "animate-fade-in-up"
             }`}
-            style={
-              popupPosition
+            style={{
+              ...(popupPosition
                 ? { left: popupPosition.left, top: popupPosition.top }
-                : { visibility: "hidden", left: 0, top: 0 }
-            }
+                : { visibility: "hidden", left: 0, top: 0 }),
+              ...win2kTooltipStyle,
+            }}
           >
-            <div className="border-b border-[#333333] px-3 pb-1.5 pt-2">
-              <span className="text-xs font-bold uppercase tracking-wider bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
-                {label}
-              </span>
+            <div className="win-titlebar" style={{ fontSize: "10px", padding: "2px 6px" }}>
+              <span className="truncate">{label}</span>
             </div>
-            <div className="p-3 pt-2">
-              <div className="relative w-full overflow-hidden rounded-lg border border-[#333333] bg-[#111111]" style={{ minHeight: 160 }}>
+            <div style={{ padding: "6px" }}>
+              <div className="relative w-full overflow-hidden" style={{
+                minHeight: 160,
+                borderTop: "1px solid #808080", borderLeft: "1px solid #808080",
+                borderRight: "1px solid #ffffff", borderBottom: "1px solid #ffffff",
+                background: "#ffffff",
+              }}>
                 {thumbnailLoading && (
-                  <div className="absolute inset-0 flex items-center justify-center bg-[#111111]">
-                    <Loader2 className="h-6 w-6 animate-spin text-white/70" />
+                  <div className="absolute inset-0 flex items-center justify-center" style={{ background: "#ffffff" }}>
+                    <Loader2 className="h-6 w-6 animate-spin" style={{ color: "#000080" }} />
                   </div>
                 )}
                 {thumbnailError ? (
-                  <div className="flex items-center justify-center px-3 py-8 text-center text-xs text-white/70">
+                  <div className="flex items-center justify-center px-3 py-8 text-center" style={{ fontSize: "10px", color: "#444444" }}>
                     Unable to load image
                   </div>
                 ) : (
@@ -318,16 +335,18 @@ const TooltipWrapper = ({ label, children, url, imageUrl, fullWidth = false }: P
             ref={popupRef}
             role="tooltip"
             aria-label={label}
-            className={`fixed z-[9999] pointer-events-none max-w-[90vw] rounded-md bg-red-600 px-2 py-1 text-xs text-white shadow-md ${
+            className={`fixed z-[9999] pointer-events-none max-w-[90vw] ${
               isClosing ? "animate-fade-out-down" : "animate-fade-in-up"
             }`}
-            style={
-              popupPosition
+            style={{
+              ...(popupPosition
                 ? { left: popupPosition.left, top: popupPosition.top }
-                : { visibility: "hidden", left: 0, top: 0 }
-            }
+                : { visibility: "hidden", left: 0, top: 0 }),
+              ...win2kTooltipStyle,
+              padding: "3px 6px",
+            }}
           >
-            <span className="whitespace-normal break-words">{label}</span>
+            <span style={{ fontSize: "11px", color: "#000000", whiteSpace: "normal", wordBreak: "break-word" }}>{label}</span>
           </div>,
           document.body
         )

--- a/src/app/components/pages/About.tsx
+++ b/src/app/components/pages/About.tsx
@@ -167,7 +167,19 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
               event.stopPropagation()
             }}
             onClick={(event) => handleCardTagClick(event, tag)}
-            className="text-xs px-3 py-1 rounded-full whitespace-nowrap max-w-full min-w-0 truncate transition-all duration-200 border cursor-pointer active:scale-95 bg-[#3a3a3a] text-gray-300 border-transparent hover:bg-[#444444] hover:scale-105 hover:shadow-lg hover:shadow-red-600/30 hover:border-red-600 hover:text-[#dc2626]"
+            style={{
+              fontSize: "9px",
+              padding: "1px 5px",
+              background: "#c0bdb4",
+              color: "#000000",
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+              fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+              borderTop: "1px solid #808080",
+              borderLeft: "1px solid #808080",
+              borderRight: "1px solid #ffffff",
+              borderBottom: "1px solid #ffffff",
+            }}
           >
             {tag.toUpperCase()}
           </span>
@@ -180,24 +192,40 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
     const { name, icon: Icon, highlight, url, year } = item
     const cardTags = item.tags ?? []
     const card = (
-      <div className={`group relative z-0 hover:z-10 flex items-start gap-4 bg-[#151515] hover:bg-[#252525] p-5 rounded-none border border-[#333333] hover:border-red-600/50 transition-all duration-300 ease-out hover:scale-[1.02] hover:shadow-lg hover:shadow-red-600/30 ${cardSizeClass}`}>
+      <div className={`group relative z-0 hover:z-10 flex items-start gap-3 p-3 transition-all duration-150 ${cardSizeClass}`}
+        style={{
+          background: "#d4d0c8",
+          borderTop: "1px solid #808080",
+          borderLeft: "1px solid #808080",
+          borderRight: "1px solid #ffffff",
+          borderBottom: "1px solid #ffffff",
+          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+          cursor: url ? "pointer" : "default",
+        }}
+      >
         <div
-          className={`flex-shrink-0 p-3 rounded-lg shadow-lg ${
-            highlight ? "bg-gradient-to-br from-red-500/80 to-red-700/80" : "bg-red-600/40 group-hover:bg-red-600/50"
-          }`}
+          className="flex-shrink-0 flex items-center justify-center"
+          style={{
+            width: 32, height: 32,
+            background: highlight ? "#000080" : "#c0bdb4",
+            borderTop: "1px solid #ffffff",
+            borderLeft: "1px solid #ffffff",
+            borderRight: "1px solid #404040",
+            borderBottom: "1px solid #404040",
+          }}
         >
-          <Icon className="text-white text-xl" />
+          <Icon style={{ color: highlight ? "#ffffff" : "#000080", fontSize: "14px" }} />
         </div>
         <div className="flex-1 min-w-0">
-          <p className="text-white font-semibold text-base break-words whitespace-normal group-hover:text-[#dc2626] transition-colors duration-300">
+          <p style={{ fontSize: "11px", fontWeight: "bold", color: "#000000", wordBreak: "break-word", whiteSpace: "normal" }}>
             {name}
           </p>
-          {year && <span className="text-gray-400 text-sm">{year}</span>}
+          {year && <span style={{ fontSize: "10px", color: "#444444" }}>{year}</span>}
           {renderFilterTags(cardTags)}
         </div>
         {url && (
-          <div className="absolute bottom-3 right-3 text-gray-400 group-hover:text-[#dc2626] transition-colors duration-300">
-            {url.endsWith(".pdf") ? <FaFilePdf size={14} aria-label="View Certification" /> : <FaExternalLinkAlt size={14} aria-label="Open external link" />}
+          <div className="absolute bottom-2 right-2" style={{ color: "#808080" }}>
+            {url.endsWith(".pdf") ? <FaFilePdf size={11} aria-label="View Certification" /> : <FaExternalLinkAlt size={11} aria-label="Open external link" />}
           </div>
         )}
       </div>
@@ -242,23 +270,39 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
     const { name, icon: Icon, highlight, url } = item
     const cardTags = Array.from(new Set([highlight ? "Hard Skills" : "Soft Skills", ...(item.tags ?? [])]))
     const card = (
-      <div className={`group relative z-0 hover:z-10 flex items-start gap-4 bg-[#151515] hover:bg-[#252525] p-5 rounded-none border border-[#333333] hover:border-red-600/50 transition-all duration-300 ease-out hover:scale-[1.02] hover:shadow-lg hover:shadow-red-600/30 ${cardSizeClass}`}>
+      <div className={`group relative z-0 hover:z-10 flex items-start gap-3 p-3 transition-all duration-150 ${cardSizeClass}`}
+        style={{
+          background: "#d4d0c8",
+          borderTop: "1px solid #808080",
+          borderLeft: "1px solid #808080",
+          borderRight: "1px solid #ffffff",
+          borderBottom: "1px solid #ffffff",
+          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+          cursor: url ? "pointer" : "default",
+        }}
+      >
         <div
-          className={`flex-shrink-0 p-3 rounded-lg shadow-lg ${
-            highlight ? "bg-gradient-to-br from-red-500/80 to-red-700/80" : "bg-red-600/40 group-hover:bg-red-600/50"
-          }`}
+          className="flex-shrink-0 flex items-center justify-center"
+          style={{
+            width: 32, height: 32,
+            background: highlight ? "#000080" : "#c0bdb4",
+            borderTop: "1px solid #ffffff",
+            borderLeft: "1px solid #ffffff",
+            borderRight: "1px solid #404040",
+            borderBottom: "1px solid #404040",
+          }}
         >
-          <Icon className="text-white text-xl" />
+          <Icon style={{ color: highlight ? "#ffffff" : "#000080", fontSize: "14px" }} />
         </div>
         <div className="min-w-0">
-          <p className="text-white font-semibold text-base break-words whitespace-normal group-hover:text-[#dc2626] transition-colors duration-300">
+          <p style={{ fontSize: "11px", fontWeight: "bold", color: "#000000", wordBreak: "break-word", whiteSpace: "normal" }}>
             {name}
           </p>
           {renderFilterTags(cardTags)}
         </div>
         {url && !url.endsWith(".pdf") && (
-          <div className="absolute bottom-3 right-3 text-gray-400 group-hover:text-[#dc2626] transition-colors duration-300">
-            <FaExternalLinkAlt size={14} aria-label="Open external link" />
+          <div className="absolute bottom-2 right-2" style={{ color: "#808080" }}>
+            <FaExternalLinkAlt size={11} aria-label="Open external link" />
           </div>
         )}
       </div>
@@ -392,14 +436,27 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
 
   return (
     <>
-      <div className="bg-[#222222] rounded-xl border border-[#333333] p-6 mb-6 animate-fadeInScale">
-        <div className="mb-5 text-center">
-          <h2 className="text-3xl font-bold text-center mb-2 bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent transition-transform">
+      <div className="mb-6 animate-fadeInScale" style={{
+        background: "#d4d0c8",
+        borderTop: "2px solid #ffffff",
+        borderLeft: "2px solid #ffffff",
+        borderRight: "2px solid #404040",
+        borderBottom: "2px solid #404040",
+        fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+      }}>
+        {/* Win2K title bar */}
+        <div className="win-titlebar">
+          <span style={{ fontSize: "11px" }}>📁 About — Ethan Townsend</span>
+        </div>
+
+        <div className="p-4">
+        <div className="mb-4 text-center">
+          <h2 style={{ fontSize: "16px", fontWeight: "bold", color: "#000080" }}>
             Welcome to My Portfolio
           </h2>
         </div>
 
-        <p className="mt-4 text-gray-300 max-w-2xl mx-auto text-center">
+        <p className="mt-2 max-w-2xl mx-auto text-center" style={{ fontSize: "11px", color: "#000000" }}>
           I am Ethan Townsend, a Full-Stack Software Engineer with a passion for back-end development.
           <br />
           <br />
@@ -407,54 +464,60 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
           <button
             type="button"
             onClick={() => handleJump("about", "certifications")}
-            className="text-red-500 hover:text-red-300 underline-offset-4 hover:underline decoration-red-400/70 decoration-2 inline-flex items-center gap-1 transition-all duration-200 hover:scale-[1.02]"
+            className="inline-flex items-center gap-1"
+            style={{ color: "#000080", textDecoration: "underline", fontSize: "11px", background: "transparent", border: "none", cursor: "pointer" }}
           >
-            <FaCertificate className="text-base" />
+            <FaCertificate style={{ fontSize: "11px" }} />
             Certifications
           </button>
           ,{" "}
           <button
             type="button"
             onClick={() => handleJump("about", "skills")}
-            className="text-red-500 hover:text-red-300 underline-offset-4 hover:underline decoration-red-400/70 decoration-2 inline-flex items-center gap-1 transition-all duration-200 hover:scale-[1.02]"
+            className="inline-flex items-center gap-1"
+            style={{ color: "#000080", textDecoration: "underline", fontSize: "11px", background: "transparent", border: "none", cursor: "pointer" }}
           >
-            <FaTools className="text-base" />
+            <FaTools style={{ fontSize: "11px" }} />
             Skills
           </button>
           ,{" "}
           <button
             type="button"
             onClick={() => handleJump("career", "experience")}
-            className="text-red-500 hover:text-red-300 underline-offset-4 hover:underline decoration-red-400/70 decoration-2 inline-flex items-center gap-1 transition-all duration-200 hover:scale-[1.02]"
+            className="inline-flex items-center gap-1"
+            style={{ color: "#000080", textDecoration: "underline", fontSize: "11px", background: "transparent", border: "none", cursor: "pointer" }}
           >
-            <FaBriefcase className="text-base" />
+            <FaBriefcase style={{ fontSize: "11px" }} />
             Experience
           </button>
           ,{" "}
           <button
             type="button"
             onClick={() => handleJump("career", "education")}
-            className="text-red-500 hover:text-red-300 underline-offset-4 hover:underline decoration-red-400/70 decoration-2 inline-flex items-center gap-1 transition-all duration-200 hover:scale-[1.02]"
+            className="inline-flex items-center gap-1"
+            style={{ color: "#000080", textDecoration: "underline", fontSize: "11px", background: "transparent", border: "none", cursor: "pointer" }}
           >
-            <FaGraduationCap className="text-base" />
+            <FaGraduationCap style={{ fontSize: "11px" }} />
             Education
           </button>
           , and{" "}
           <button
             type="button"
             onClick={() => handleJump("projects", "projects")}
-            className="text-red-500 hover:text-red-300 underline-offset-4 hover:underline decoration-red-400/70 decoration-2 inline-flex items-center gap-1 transition-all duration-200 hover:scale-[1.02]"
+            className="inline-flex items-center gap-1"
+            style={{ color: "#000080", textDecoration: "underline", fontSize: "11px", background: "transparent", border: "none", cursor: "pointer" }}
           >
-            <FaFolderOpen className="text-base" />
+            <FaFolderOpen style={{ fontSize: "11px" }} />
             Projects
           </button>
           ,{" "}
           <button
             type="button"
             onClick={() => handleJump("projects", "repos")}
-            className="text-red-500 hover:text-red-300 underline-offset-4 hover:underline decoration-red-400/70 decoration-2 inline-flex items-center gap-1 transition-all duration-200 hover:scale-[1.02]"
+            className="inline-flex items-center gap-1"
+            style={{ color: "#000080", textDecoration: "underline", fontSize: "11px", background: "transparent", border: "none", cursor: "pointer" }}
           >
-            <FaGithub className="text-base" />
+            <FaGithub style={{ fontSize: "11px" }} />
             Repositories
           </button>
           .
@@ -462,16 +525,22 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
           <br />
         </p>
 
-        <div className="flex justify-center mb-4">
+        <div className="flex justify-center mb-3">
           <PageTabs
             tabs={tabs}
             activeId={activeSubsection}
             onChange={handleAboutTabChange}
           />
-
         </div>
 
-        <div className="bg-[#1e1e1e] border border-[#333333] rounded-xl py-4 px-4">
+        <div style={{
+          background: "#ffffff",
+          borderTop: "1px solid #808080",
+          borderLeft: "1px solid #808080",
+          borderRight: "1px solid #ffffff",
+          borderBottom: "1px solid #ffffff",
+          padding: "6px 8px",
+        }}>
           <div className="container mx-auto">
             <SearchFilterBar
               search={search}
@@ -492,11 +561,12 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
             />
 
             {resultsCount && (
-              <div className="text-sm text-gray-400 mt-2 text-center sm:text-left">{resultsCount}</div>
+              <div style={{ fontSize: "10px", color: "#444444", marginTop: "4px" }}>{resultsCount}</div>
             )}
           </div>
         </div>
-      </div>
+        </div>{/* end p-4 */}
+      </div>{/* end win-window */}
 
       <div
         id="about-cards"
@@ -508,18 +578,21 @@ const About = ({ onTabChange, externalSubsection, onExternalSubsectionConsumed, 
             renderCard={(i) => (
               <div
                 key={i}
-                className="bg-[#151515] border border-[#333333] p-5 rounded-none animate-pulse min-h-[180px]"
+                className="animate-pulse min-h-[120px] p-3"
+                style={{
+                  background: "#d4d0c8",
+                  borderTop: "1px solid #808080",
+                  borderLeft: "1px solid #808080",
+                  borderRight: "1px solid #ffffff",
+                  borderBottom: "1px solid #ffffff",
+                }}
               >
-                <div className="flex items-start gap-4">
-                  <div className="w-11 h-11 bg-[#333333] rounded-lg" />
+                <div className="flex items-start gap-3">
+                  <div style={{ width: 32, height: 32, background: "#c0bdb4" }} />
                   <div className="flex-1 space-y-2">
-                    <div className="h-4 bg-[#333333] rounded w-3/4" />
-                    <div className="h-3 bg-[#333333] rounded w-1/3" />
+                    <div style={{ height: "10px", background: "#c0bdb4", width: "75%" }} />
+                    <div style={{ height: "9px", background: "#c0bdb4", width: "40%" }} />
                   </div>
-                </div>
-                <div className="space-y-2 mt-5">
-                  <div className="h-3 bg-[#333333] rounded w-full" />
-                  <div className="h-3 bg-[#333333] rounded w-5/6" />
                 </div>
               </div>
             )}

--- a/src/app/components/pages/Footer.tsx
+++ b/src/app/components/pages/Footer.tsx
@@ -13,91 +13,96 @@ const Footer = () => {
     setLoading(false)
   }, [])
 
+  const footerStyle: React.CSSProperties = {
+    background: "linear-gradient(to bottom, #d4d0c8, #bab8b0)",
+    borderTop: "2px solid #ffffff",
+    borderBottom: "2px solid #404040",
+    padding: "4px 12px",
+    fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+    fontSize: "11px",
+    color: "#000000",
+  }
+
   if (loading) {
     return (
-      <footer className="bg-[#121212] text-gray-400 w-full py-6 px-6">
-        <div className="max-w-8xl mx-auto flex flex-col items-center gap-6">
-          <div className="w-full flex flex-col lg:flex-row items-center justify-between gap-4 text-sm">
-            {/* Left: Summary Skeleton */}
-            <div className="order-3 lg:order-1 mt-2 lg:mt-0">
-              <div className="h-5 w-48 bg-[#333333] rounded animate-pulse" />
-            </div>
-
-            {/* Center: Logo & Name Skeleton */}
-            <div className="order-1 lg:order-2 flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-[#333333] animate-pulse" />
-              <div className="h-5 w-40 bg-[#333333] rounded animate-pulse" />
-            </div>
-
-            {/* Right: Domain Links Skeleton */}
-            <div className="order-2 lg:order-3">
-              <div className="footer-links flex flex-col sm:flex-row items-center gap-2">
-                <div className="flex gap-4">
-                  <div className="h-5 w-16 bg-[#333333] rounded animate-pulse" />
-                  <div className="h-5 w-24 bg-[#333333] rounded animate-pulse" />
-                </div>
-              </div>
-            </div>
+      <footer style={footerStyle} className="w-full">
+        <div className="max-w-8xl mx-auto flex flex-col lg:flex-row items-center justify-between gap-2 animate-pulse">
+          <div style={{ height: 16, width: 120, background: "#c0bdb4" }} />
+          <div className="flex items-center gap-2">
+            <div style={{ width: 20, height: 20, background: "#c0bdb4" }} />
+            <div style={{ height: 14, width: 140, background: "#c0bdb4" }} />
+          </div>
+          <div className="flex gap-3">
+            <div style={{ height: 14, width: 60, background: "#c0bdb4" }} />
+            <div style={{ height: 14, width: 80, background: "#c0bdb4" }} />
           </div>
         </div>
       </footer>
     )
   }
+
   return (
-    <footer className="bg-[#121212] text-gray-400 w-full py-6 px-6">
-      <div className="max-w-8xl mx-auto flex flex-col items-center gap-6">
-        <div className="w-full flex flex-col lg:flex-row items-center justify-between gap-4 text-sm">
-          {/* Left: Professional Links */}
-          <div className="order-3 lg:order-1 mt-2 lg:mt-0">
-            <div className="flex items-center gap-4">
-              {socialLinks.professional.map(({ label, icon, url, tooltip }) => {
-                const Icon = Icons[icon as keyof typeof Icons]
-                return (
-                  <TooltipWrapper key={label} label={tooltip}>
-                    <a
-                      href={url}
-                      target="_blank"
-                      rel="noreferrer"
-                      aria-label={label}
-                      className="text-gray-400 hover:text-red-600 text-xl transition-all duration-200 ease-out hover:scale-110"
-                    >
-                      <Icon />
-                    </a>
-                  </TooltipWrapper>
-                )
-              })}
-            </div>
-          </div>
+    <footer style={footerStyle} className="w-full">
+      <div className="max-w-8xl mx-auto flex flex-col lg:flex-row items-center justify-between gap-2">
+        {/* Left: Professional Links */}
+        <div className="order-3 lg:order-1 flex items-center gap-2">
+          {socialLinks.professional.map(({ label, icon, url, tooltip }) => {
+            const Icon = Icons[icon as keyof typeof Icons]
+            return (
+              <TooltipWrapper key={label} label={tooltip}>
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={label}
+                  className="flex items-center justify-center"
+                  style={{
+                    background: "#d4d0c8",
+                    borderTop: "1px solid #fff",
+                    borderLeft: "1px solid #fff",
+                    borderRight: "1px solid #404040",
+                    borderBottom: "1px solid #404040",
+                    width: "22px", height: "20px",
+                    fontSize: "12px",
+                    color: "#000080",
+                  }}
+                  onMouseEnter={e => (e.currentTarget.style.background = "#c0bdb4")}
+                  onMouseLeave={e => (e.currentTarget.style.background = "#d4d0c8")}
+                >
+                  <Icon />
+                </a>
+              </TooltipWrapper>
+            )
+          })}
+        </div>
 
-          {/* Center: Logo & Name */}
-          <div className="order-1 lg:order-2 flex items-center gap-2">
-            <Image
-              src="/images/avatar/snex.png"
-              alt="Ethan Townsend"
-              width={32}
-              height={32}
-              className="rounded-full transition-transform duration-300 ease-in-out hover:-translate-y-1 hover:scale-105"
-            />
-            <TooltipWrapper label="My Portfolio">
-              <a href="https://ethantownsend.dev" className="text-sm text-gray-400 hover:text-red-600 transition-colors duration-200">
-                Ethan Townsend &copy; {new Date().getFullYear()}
-              </a>
-            </TooltipWrapper>
-          </div>
+        {/* Center: Logo & Name */}
+        <div className="order-1 lg:order-2 flex items-center gap-2">
+          <Image
+            src="/images/avatar/snex.png"
+            alt="Ethan Townsend"
+            width={20}
+            height={20}
+            style={{ width: 20, height: 20, objectFit: "cover" }}
+          />
+          <TooltipWrapper label="My Portfolio">
+            <a href="https://ethantownsend.dev" style={{ color: "#000080", textDecoration: "none", fontSize: "11px" }}
+              onMouseEnter={e => (e.currentTarget.style.textDecoration = "underline")}
+              onMouseLeave={e => (e.currentTarget.style.textDecoration = "none")}
+            >
+              Ethan Townsend &copy; {new Date().getFullYear()}
+            </a>
+          </TooltipWrapper>
+        </div>
 
-          {/* Right: Domain Links */}
-          <div className="order-2 lg:order-3">
-            <div className="footer-links flex flex-col sm:flex-row items-center gap-2">
-              <div className="flex gap-4">
-                <Link href="https://snex.dev" className="hover:text-red-600 hover:scale-105 transition-all duration-200">
-                  snex.dev
-                </Link>
-                <Link href="https://snxethan.dev" className="hover:text-red-600 hover:scale-105 transition-all duration-200">
-                  snxethan.dev
-                </Link>
-              </div>
-            </div>
-          </div>
+        {/* Right: Domain Links */}
+        <div className="order-2 lg:order-3 flex gap-3">
+          <Link href="https://snex.dev" style={{ color: "#000080", fontSize: "11px" }}>
+            snex.dev
+          </Link>
+          <Link href="https://snxethan.dev" style={{ color: "#000080", fontSize: "11px" }}>
+            snxethan.dev
+          </Link>
         </div>
       </div>
     </footer>

--- a/src/app/components/pages/HomeClient.tsx
+++ b/src/app/components/pages/HomeClient.tsx
@@ -626,7 +626,7 @@ export default function HomeClient() {
   const isSectionRailEnabled = !isNavPinned
 
   return (
-    <div className="flex flex-col min-h-screen bg-gradient-to-b from-[#1a1a1a] via-[#121212] to-[#0d0d0d] text-white font-sans min-w-[360px]">
+    <div className="flex flex-col min-h-screen min-w-[360px]" style={{ background: "#ece9d8", color: "#000000", fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif' }}>
       <SectionScrollRail
         items={sectionRailItems}
         activeSection={activeSection}

--- a/src/app/components/pages/Navbar.tsx
+++ b/src/app/components/pages/Navbar.tsx
@@ -226,44 +226,71 @@ const Navbar = ({ onTabChange, activePage, activeTab, onPinChange, enableHoverPo
     <>
     <nav
       ref={navRef}
-      className={`w-full bg-[#222222] py-4 px-6 md:px-8 lg:px-10 ${isNavPinned ? 'fixed ring-1 ring-[#2a2a2a] shadow-lg shadow-black/20' : 'relative'} top-0 left-0 z-50 border-b border-[#333333] md:border-0 transition-all duration-300 ease-in-out ${isPinAnimating ? "animate-pin-bounce" : ""}`}
+      className={`w-full ${isNavPinned ? 'fixed' : 'relative'} top-0 left-0 z-50 ${isPinAnimating ? "animate-pin-bounce" : ""}`}
+      style={{
+        background: "linear-gradient(to bottom, #d4d0c8, #c0bdb4)",
+        borderBottom: "2px solid #808080",
+        borderTop: "2px solid #ffffff",
+        boxShadow: "0 2px 0 #404040",
+        fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+      }}
     >
-      <div className="container mx-auto">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
-          <div className="flex items-center justify-center lg:justify-start">
-            <h1 className="w-full text-2xl font-bold text-center lg:text-left bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
-              ethantownsend.dev
-            </h1>
-            <button
-              onClick={handlePinToggle}
-              className={`lg:hidden p-1 transition-all duration-300 hover:scale-110 ${
-                isNavPinned
-                  ? "text-red-600"
-                  : "text-gray-400 hover:text-red-500"
-              }`}
-              aria-label={isNavPinned ? "Unpin navigation (navbar will not follow scroll)" : "Pin navigation (navbar will follow scroll)"}
-              title={isNavPinned ? "Click to unpin" : "Click to pin"}
-            >
-              <FaThumbtack size={18} className={`transition-transform duration-300 ${isNavPinned ? "rotate-0" : "rotate-45"}`} />
-            </button>
+      {/* Win2K title bar strip */}
+      <div className="win-titlebar px-4 py-1">
+        <span style={{ fontSize: "11px", fontWeight: "bold", letterSpacing: "0.02em" }}>
+          🖥️ ethantownsend.dev — Portfolio Navigator
+        </span>
+        <div className="ml-auto flex gap-1">
+          <button
+            onClick={handlePinToggle}
+            style={{
+              background: "#d4d0c8",
+              borderTop: "1px solid #fff",
+              borderLeft: "1px solid #fff",
+              borderRight: "1px solid #404040",
+              borderBottom: "1px solid #404040",
+              width: "16px",
+              height: "14px",
+              fontSize: "9px",
+              lineHeight: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+              color: "#000",
+            }}
+            aria-label={isNavPinned ? "Unpin navigation" : "Pin navigation"}
+            title={isNavPinned ? "Click to unpin" : "Click to pin"}
+          >
+            <FaThumbtack size={8} style={{ transform: isNavPinned ? "rotate(0deg)" : "rotate(45deg)" }} />
+          </button>
+        </div>
+      </div>
+
+      {/* Nav buttons area */}
+      <div className="container mx-auto px-4 py-1">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+          <div className="flex items-center justify-center lg:justify-start gap-2">
+            <span style={{ fontSize: "13px", fontWeight: "bold", color: "#000080" }}>
+              Navigation:
+            </span>
           </div>
 
-          <div className="flex items-center gap-3 lg:ml-auto lg:justify-end w-full lg:w-auto">
+          <div className="flex items-center gap-2 lg:ml-2 w-full lg:w-auto">
             <div
               ref={navContentRef}
-              className="flex gap-3 transition-all duration-500 ease-in-out w-full lg:w-auto flex-wrap justify-center lg:justify-end"
+              className="flex gap-2 w-full lg:w-auto flex-wrap justify-center lg:justify-start"
             >
               {isLoading ? (
-                <div className="flex space-x-4 animate-pulse justify-center w-full">
+                <div className="flex space-x-2 justify-center w-full">
                   {[...Array(3)].map((_, i) => (
-                    <div key={i} className="w-24 h-9 bg-[#333333] rounded-lg" />
+                    <div key={i} className="win-btn animate-pulse" style={{ width: "80px", height: "22px" }} />
                   ))}
                 </div>
               ) : (
-                <div className="bg-[#1e1e1e] border border-[#333333] rounded-xl py-3 px-4 flex items-center gap-2 flex-wrap justify-center lg:justify-end w-full lg:w-auto">
+                <div className="flex items-center gap-1 flex-wrap justify-center lg:justify-start w-full lg:w-auto">
                   {mainTabs.map((tab) => {
                     const isActive = activePage === tab.id
-
                     return (
                       <button
                         key={tab.id}
@@ -296,13 +323,25 @@ const Navbar = ({ onTabChange, activePage, activeTab, onPinChange, enableHoverPo
                             longPressTimerRef.current = null
                           }
                         }}
-                        className={`inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-medium transition-all duration-200 hover:scale-105 border focus:outline-none focus-visible:outline-none ${
-                          isActive
-                            ? "bg-gradient-to-r from-red-600 to-red-500 text-white scale-105 shadow-lg shadow-red-600/40 cursor-pointer border-transparent"
-                            : "bg-[#2a2a2a] text-gray-300 hover:bg-[#333333] hover:text-[#dc2626] hover:border-red-600 hover:shadow-lg hover:shadow-red-600/30 cursor-pointer border-transparent"
-                        }`}
+                        className={`inline-flex items-center gap-1.5 focus:outline-none focus-visible:outline-2 focus-visible:outline-[#000080] ${isActive ? "win-btn-active" : ""}`}
+                        style={{
+                          background: isActive ? "#c0bdb4" : "#d4d0c8",
+                          borderTopColor: isActive ? "#404040" : "#ffffff",
+                          borderLeftColor: isActive ? "#404040" : "#ffffff",
+                          borderRightColor: isActive ? "#ffffff" : "#404040",
+                          borderBottomColor: isActive ? "#ffffff" : "#404040",
+                          borderStyle: "solid",
+                          borderWidth: "1px",
+                          padding: "3px 10px",
+                          fontSize: "11px",
+                          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+                          fontWeight: isActive ? "bold" : "normal",
+                          color: "#000000",
+                          cursor: "pointer",
+                          minWidth: "70px",
+                        }}
                       >
-                        {tab.icon && <span className="text-lg">{tab.icon}</span>}
+                        {tab.icon && <span style={{ fontSize: "12px" }}>{tab.icon}</span>}
                         <span>{tab.label}</span>
                       </button>
                     )
@@ -310,19 +349,6 @@ const Navbar = ({ onTabChange, activePage, activeTab, onPinChange, enableHoverPo
                 </div>
               )}
             </div>
-
-            <button
-              onClick={handlePinToggle}
-              className={`hidden lg:inline-flex p-1 transition-all duration-300 hover:scale-110 ${
-                isNavPinned
-                  ? "text-red-600"
-                  : "text-gray-400 hover:text-red-500"
-              }`}
-              aria-label={isNavPinned ? "Unpin navigation (navbar will not follow scroll)" : "Pin navigation (navbar will follow scroll)"}
-              title={isNavPinned ? "Click to unpin" : "Click to pin"}
-            >
-              <FaThumbtack size={18} className={`transition-transform duration-300 ${isNavPinned ? "rotate-0" : "rotate-45"}`} />
-            </button>
           </div>
         </div>
       </div>
@@ -391,15 +417,24 @@ function ContextMenuPopup({ contextMenuRef, page, anchorId, subItems, onTabChang
       ref={contextMenuRef}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      className={`fixed z-[9999] min-w-[140px] max-w-[220px] rounded-lg border border-[#333333] bg-[#1e1e1e] py-1.5 shadow-2xl shadow-black/40 ${
+      className={`fixed z-[9999] min-w-[140px] max-w-[200px] ${
         isClosing ? "animate-fade-out-down" : "animate-fade-in-up"
       }`}
-      style={pos ? { left: pos.left, top: pos.top } : { visibility: "hidden", left: 0, top: 0 }}
+      style={{
+        ...(pos ? { left: pos.left, top: pos.top } : { visibility: "hidden", left: 0, top: 0 }),
+        background: "#d4d0c8",
+        borderTop: "1px solid #ffffff",
+        borderLeft: "1px solid #ffffff",
+        borderRight: "1px solid #404040",
+        borderBottom: "1px solid #404040",
+        boxShadow: "2px 2px 4px rgba(0,0,0,0.5)",
+        padding: "2px",
+        fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+      }}
     >
-      <div className="mb-1 border-b border-[#333333] px-2.5 pb-1 pt-0.5">
-        <span className="text-xs font-bold uppercase tracking-wider bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
-          {sectionLabel}
-        </span>
+      {/* Win2K menu title bar */}
+      <div className="win-titlebar mb-0.5" style={{ fontSize: "11px", padding: "2px 6px" }}>
+        <span>{sectionLabel}</span>
       </div>
       {subItems[page]?.map((item) => (
         <button
@@ -408,9 +443,26 @@ function ContextMenuPopup({ contextMenuRef, page, anchorId, subItems, onTabChang
             onTabChange(page, item.tab)
             closeContextMenu()
           }}
-          className="group flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs text-gray-300 transition-all duration-150 hover:bg-[#2a2a2a] hover:text-[#dc2626] hover:shadow-[inset_0_0_8px_rgba(220,38,38,0.15)]"
+          className="flex w-full items-center gap-2 text-left"
+          style={{
+            padding: "3px 8px",
+            fontSize: "11px",
+            color: "#000000",
+            background: "transparent",
+            border: "none",
+            cursor: "default",
+            fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+          }}
+          onMouseEnter={e => {
+            (e.currentTarget as HTMLButtonElement).style.background = "#000080"
+            ;(e.currentTarget as HTMLButtonElement).style.color = "#ffffff"
+          }}
+          onMouseLeave={e => {
+            (e.currentTarget as HTMLButtonElement).style.background = "transparent"
+            ;(e.currentTarget as HTMLButtonElement).style.color = "#000000"
+          }}
         >
-          <span className="text-sm text-gray-500 transition-colors duration-150 group-hover:text-[#dc2626]">{item.icon}</span>
+          <span style={{ fontSize: "12px", width: "14px", flexShrink: 0 }}>{item.icon}</span>
           <span>{item.label}</span>
         </button>
       ))}

--- a/src/app/components/pages/SectionScrollRail.tsx
+++ b/src/app/components/pages/SectionScrollRail.tsx
@@ -1,4 +1,4 @@
-﻿"use client"
+"use client"
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import { FaUser, FaCertificate, FaTools, FaProjectDiagram, FaGithub, FaBriefcase, FaGraduationCap } from "react-icons/fa"
@@ -207,11 +207,14 @@ const SectionScrollRail = ({
             style={{ top: `${normalizedPosition * 100}%` }}
           >
             <span
-              className={`h-4 w-4 rounded-lg border transition-all duration-200 ${
-                isActive
-                  ? "bg-gradient-to-r from-red-600 to-red-500 border-transparent shadow-lg shadow-red-600/40"
-                  : "bg-[#2a2a2a] border-transparent hover:bg-[#333333] hover:border-red-600 hover:shadow-lg hover:shadow-red-600/30"
-              }`}
+              className="h-4 w-4 transition-all duration-200"
+              style={{
+                background: isActive ? "#000080" : "#d4d0c8",
+                borderTop: "1px solid #ffffff",
+                borderLeft: "1px solid #ffffff",
+                borderRight: "1px solid #404040",
+                borderBottom: "1px solid #404040",
+              }}
             />
           </button>
         )
@@ -228,19 +231,25 @@ const SectionScrollRail = ({
             }
           }}
           onMouseLeave={scheduleClose}
-          className={`fixed z-[9999] min-w-[140px] max-w-[220px] rounded-lg border border-[#333333] bg-[#1e1e1e] py-1.5 shadow-2xl shadow-black/40 ${
+          className={`fixed z-[9999] min-w-[140px] max-w-[200px] ${
             contextMenu.isClosing ? "animate-fade-out-down" : "animate-fade-in-up"
           }`}
           style={{
             ...(popupPosition
               ? { left: popupPosition.left, top: popupPosition.top }
               : { visibility: "hidden", left: 0, top: 0 }),
+            background: "#d4d0c8",
+            borderTop: "1px solid #ffffff",
+            borderLeft: "1px solid #ffffff",
+            borderRight: "1px solid #404040",
+            borderBottom: "1px solid #404040",
+            boxShadow: "2px 2px 4px rgba(0,0,0,0.5)",
+            padding: "2px",
+            fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
           }}
         >
-          <div className="mb-1 border-b border-[#333333] px-2.5 pb-1 pt-0.5">
-            <span className="text-xs font-bold uppercase tracking-wider bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
-              {sectionLabel}
-            </span>
+          <div className="win-titlebar mb-0.5" style={{ fontSize: "11px", padding: "2px 6px" }}>
+            <span>{sectionLabel}</span>
           </div>
           {subItems[contextMenu.page].map((subItem) => (
             <button
@@ -250,9 +259,26 @@ const SectionScrollRail = ({
                 onTabChange(contextMenu.page, subItem.tab)
                 closeContextMenu()
               }}
-              className="group flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs text-gray-300 transition-all duration-150 hover:bg-[#2a2a2a] hover:text-[#dc2626] hover:shadow-[inset_0_0_8px_rgba(220,38,38,0.15)]"
+              className="flex w-full items-center gap-2 text-left"
+              style={{
+                padding: "3px 8px",
+                fontSize: "11px",
+                color: "#000000",
+                background: "transparent",
+                border: "none",
+                cursor: "default",
+                fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+              }}
+              onMouseEnter={e => {
+                (e.currentTarget as HTMLButtonElement).style.background = "#000080"
+                ;(e.currentTarget as HTMLButtonElement).style.color = "#ffffff"
+              }}
+              onMouseLeave={e => {
+                (e.currentTarget as HTMLButtonElement).style.background = "transparent"
+                ;(e.currentTarget as HTMLButtonElement).style.color = "#000000"
+              }}
             >
-              <span className="text-sm text-gray-500 transition-colors duration-150 group-hover:text-[#dc2626]">{subItem.icon}</span>
+              <span style={{ fontSize: "12px", width: "14px", flexShrink: 0 }}>{subItem.icon}</span>
               <span>{subItem.label}</span>
             </button>
           ))}

--- a/src/app/components/pages/portfolio/EducationPage.tsx
+++ b/src/app/components/pages/portfolio/EducationPage.tsx
@@ -182,7 +182,7 @@ const EducationPage = ({ onTabChange, activeTab, onContentReady }: EducationPage
 
     if (filteredItems.length === 0) {
       return (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center py-8" style={{ fontSize: "11px", color: "#444444", fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif' }}>
           <p>No items match your current filters.</p>
         </div>
       )
@@ -193,13 +193,16 @@ const EducationPage = ({ onTabChange, activeTab, onContentReady }: EducationPage
         <ResponsiveCardSkeletonGrid
           className="pb-14"
           renderCard={(i) => (
-            <div key={i} className="bg-[#151515] border border-[#333333] p-6 rounded-none animate-pulse min-h-[14rem]">
-              <div className="h-6 bg-[#333333] rounded w-3/4 mb-4" />
-              <div className="h-4 bg-[#333333] rounded w-1/2 mb-4" />
+            <div key={i} className="animate-pulse p-4 min-h-[180px]" style={{
+              background: "#d4d0c8",
+              borderTop: "1px solid #808080", borderLeft: "1px solid #808080",
+              borderRight: "1px solid #fff", borderBottom: "1px solid #fff",
+            }}>
+              <div style={{ height: 14, background: "#c0bdb4", width: "75%", marginBottom: 8 }} />
+              <div style={{ height: 11, background: "#c0bdb4", width: "50%", marginBottom: 8 }} />
               <div className="space-y-2">
-                <div className="h-3 bg-[#333333] rounded w-full" />
-                <div className="h-3 bg-[#333333] rounded w-5/6" />
-                <div className="h-3 bg-[#333333] rounded w-4/6" />
+                <div style={{ height: 10, background: "#c0bdb4" }} />
+                <div style={{ height: 10, background: "#c0bdb4", width: "83%" }} />
               </div>
             </div>
           )}
@@ -226,12 +229,26 @@ const EducationPage = ({ onTabChange, activeTab, onContentReady }: EducationPage
 
   return (
     <>
-      <div id="education-page-header" className="bg-[#222222] rounded-xl border border-[#333333] p-6 mb-6">
-        <div className="mb-6">
-          <h2 className="text-3xl font-bold text-center mb-4 bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
+      <div
+        id="education-page-header"
+        className="mb-6"
+        style={{
+          background: "#d4d0c8",
+          borderTop: "2px solid #ffffff",
+          borderLeft: "2px solid #ffffff",
+          borderRight: "2px solid #404040",
+          borderBottom: "2px solid #404040",
+          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+        }}
+      >
+        <div className="win-titlebar">
+          <span style={{ fontSize: "11px" }}>🎓 Career — Education</span>
+        </div>
+        <div className="p-4 mb-2">
+          <div style={{ fontSize: "14px", fontWeight: "bold", color: "#000080", textAlign: "center", marginBottom: "8px" }}>
             Career
-          </h2>
-          <div className="flex justify-center mb-4">
+          </div>
+          <div className="flex justify-center mb-3">
             <PageTabs
               tabs={tabs}
               activeId={activeId}
@@ -239,7 +256,14 @@ const EducationPage = ({ onTabChange, activeTab, onContentReady }: EducationPage
             />
           </div>
 
-          <div className="bg-[#1e1e1e] border border-[#333333] rounded-xl py-4 px-4">
+          <div style={{
+            background: "#ffffff",
+            borderTop: "1px solid #808080",
+            borderLeft: "1px solid #808080",
+            borderRight: "1px solid #ffffff",
+            borderBottom: "1px solid #ffffff",
+            padding: "6px 8px",
+          }}>
             <div className="container mx-auto">
               <SearchFilterBar
                 search={search}
@@ -258,15 +282,14 @@ const EducationPage = ({ onTabChange, activeTab, onContentReady }: EducationPage
                 defaultSort="newest"
                 onFilterInteraction={scrollToCards}
               />
-              <div className="text-sm text-gray-400 mt-2">{resultsCount}</div>
+              <div style={{ fontSize: "10px", color: "#444444", marginTop: "4px" }}>{resultsCount}</div>
             </div>
           </div>
-        </div>
-      </div>
+        </div>{/* end p-4 */}
+      </div>{/* end win-window */}
 
       <div
         id="education-cards"
-        className="text-white"
         style={{ scrollMarginTop: "calc(var(--navbar-height, 6rem) + 1rem)" }}
       >
         <div className="transition-opacity duration-150 opacity-100 animate-fade-in-up">

--- a/src/app/components/pages/portfolio/ExperiencePage.tsx
+++ b/src/app/components/pages/portfolio/ExperiencePage.tsx
@@ -182,7 +182,7 @@ const ExperiencePage = ({ onTabChange, activeTab, onContentReady }: ExperiencePa
 
     if (filteredItems.length === 0) {
       return (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center py-8" style={{ fontSize: "11px", color: "#444444", fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif' }}>
           <p>No items match your current filters.</p>
         </div>
       )
@@ -193,13 +193,16 @@ const ExperiencePage = ({ onTabChange, activeTab, onContentReady }: ExperiencePa
         <ResponsiveCardSkeletonGrid
           className="pb-14"
           renderCard={(i) => (
-            <div key={i} className="bg-[#151515] border border-[#333333] p-6 rounded-none animate-pulse min-h-[14rem]">
-              <div className="h-6 bg-[#333333] rounded w-3/4 mb-4" />
-              <div className="h-4 bg-[#333333] rounded w-1/2 mb-4" />
+            <div key={i} className="animate-pulse p-4 min-h-[180px]" style={{
+              background: "#d4d0c8",
+              borderTop: "1px solid #808080", borderLeft: "1px solid #808080",
+              borderRight: "1px solid #fff", borderBottom: "1px solid #fff",
+            }}>
+              <div style={{ height: 14, background: "#c0bdb4", width: "75%", marginBottom: 8 }} />
+              <div style={{ height: 11, background: "#c0bdb4", width: "50%", marginBottom: 8 }} />
               <div className="space-y-2">
-                <div className="h-3 bg-[#333333] rounded w-full" />
-                <div className="h-3 bg-[#333333] rounded w-5/6" />
-                <div className="h-3 bg-[#333333] rounded w-4/6" />
+                <div style={{ height: 10, background: "#c0bdb4" }} />
+                <div style={{ height: 10, background: "#c0bdb4", width: "83%" }} />
               </div>
             </div>
           )}
@@ -226,12 +229,26 @@ const ExperiencePage = ({ onTabChange, activeTab, onContentReady }: ExperiencePa
 
   return (
     <>
-      <div id="experience-page-header" className="bg-[#222222] rounded-xl border border-[#333333] p-6 mb-6">
-        <div className="mb-6">
-          <h2 className="text-3xl font-bold text-center mb-4 bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
+      <div
+        id="experience-page-header"
+        className="mb-6"
+        style={{
+          background: "#d4d0c8",
+          borderTop: "2px solid #ffffff",
+          borderLeft: "2px solid #ffffff",
+          borderRight: "2px solid #404040",
+          borderBottom: "2px solid #404040",
+          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+        }}
+      >
+        <div className="win-titlebar">
+          <span style={{ fontSize: "11px" }}>💼 Career</span>
+        </div>
+        <div className="p-4 mb-2">
+          <div style={{ fontSize: "14px", fontWeight: "bold", color: "#000080", textAlign: "center", marginBottom: "8px" }}>
             Career
-          </h2>
-          <div className="flex justify-center mb-4">
+          </div>
+          <div className="flex justify-center mb-3">
             <PageTabs
               tabs={tabs}
               activeId={activeId}
@@ -239,7 +256,14 @@ const ExperiencePage = ({ onTabChange, activeTab, onContentReady }: ExperiencePa
             />
           </div>
 
-          <div className="bg-[#1e1e1e] border border-[#333333] rounded-xl py-4 px-4">
+          <div style={{
+            background: "#ffffff",
+            borderTop: "1px solid #808080",
+            borderLeft: "1px solid #808080",
+            borderRight: "1px solid #ffffff",
+            borderBottom: "1px solid #ffffff",
+            padding: "6px 8px",
+          }}>
             <div className="container mx-auto">
               <SearchFilterBar
                 search={search}
@@ -258,15 +282,14 @@ const ExperiencePage = ({ onTabChange, activeTab, onContentReady }: ExperiencePa
                 defaultSort="newest"
                 onFilterInteraction={scrollToCards}
               />
-              <div className="text-sm text-gray-400 mt-2">{resultsCount}</div>
+              <div style={{ fontSize: "10px", color: "#444444", marginTop: "4px" }}>{resultsCount}</div>
             </div>
           </div>
-        </div>
-      </div>
+        </div>{/* end p-4 */}
+      </div>{/* end win-window */}
 
       <div
         id="experience-cards"
-        className="text-white"
         style={{ scrollMarginTop: "calc(var(--navbar-height, 6rem) + 1rem)" }}
       >
         <div className="transition-opacity duration-150 opacity-100 animate-fade-in-up">

--- a/src/app/components/pages/portfolio/ProjectsPage.tsx
+++ b/src/app/components/pages/portfolio/ProjectsPage.tsx
@@ -154,7 +154,7 @@ const ProjectsPage = ({ onTabChange, activeTab }: ProjectsPageProps) => {
   const renderTimeline = () => {
     if (sortedProjects.length === 0) {
       return (
-        <div className="text-center text-gray-400 py-8">
+        <div className="text-center py-8" style={{ fontSize: "11px", color: "#444444", fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif' }}>
           <p>No items match your current filters.</p>
         </div>
       )
@@ -164,16 +164,16 @@ const ProjectsPage = ({ onTabChange, activeTab }: ProjectsPageProps) => {
       return (
         <ResponsiveCardSkeletonGrid
           renderCard={(i) => (
-            <div
-              key={i}
-              className="bg-[#151515] border border-[#333333] p-6 rounded-none animate-pulse min-h-[14rem]"
-            >
-              <div className="h-6 bg-[#333333] rounded w-3/4 mb-4" />
-              <div className="h-4 bg-[#333333] rounded w-1/2 mb-4" />
+            <div key={i} className="animate-pulse p-4 min-h-[180px]" style={{
+              background: "#d4d0c8",
+              borderTop: "1px solid #808080", borderLeft: "1px solid #808080",
+              borderRight: "1px solid #fff", borderBottom: "1px solid #fff",
+            }}>
+              <div style={{ height: 14, background: "#c0bdb4", width: "75%", marginBottom: 8 }} />
+              <div style={{ height: 11, background: "#c0bdb4", width: "50%", marginBottom: 8 }} />
               <div className="space-y-2">
-                <div className="h-3 bg-[#333333] rounded w-full" />
-                <div className="h-3 bg-[#333333] rounded w-5/6" />
-                <div className="h-3 bg-[#333333] rounded w-4/6" />
+                <div style={{ height: 10, background: "#c0bdb4" }} />
+                <div style={{ height: 10, background: "#c0bdb4", width: "83%" }} />
               </div>
             </div>
           )}
@@ -194,12 +194,26 @@ const ProjectsPage = ({ onTabChange, activeTab }: ProjectsPageProps) => {
 
   return (
     <>
-      <div id="projects-page-header" className="bg-[#222222] rounded-xl border border-[#333333] p-6 mb-6">
-        <div className="mb-6">
-          <h2 className="text-3xl font-bold text-center mb-4 bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
+      <div
+        id="projects-page-header"
+        className="mb-6"
+        style={{
+          background: "#d4d0c8",
+          borderTop: "2px solid #ffffff",
+          borderLeft: "2px solid #ffffff",
+          borderRight: "2px solid #404040",
+          borderBottom: "2px solid #404040",
+          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+        }}
+      >
+        <div className="win-titlebar">
+          <span style={{ fontSize: "11px" }}>📁 Projects</span>
+        </div>
+        <div className="p-4 mb-2">
+          <div style={{ fontSize: "14px", fontWeight: "bold", color: "#000080", textAlign: "center", marginBottom: "8px" }}>
             Projects
-          </h2>
-          <div className="flex justify-center mb-4">
+          </div>
+          <div className="flex justify-center mb-3">
             <PageTabs
               tabs={tabs}
               activeId={activeId}
@@ -207,7 +221,14 @@ const ProjectsPage = ({ onTabChange, activeTab }: ProjectsPageProps) => {
             />
           </div>
 
-          <div className="bg-[#1e1e1e] border border-[#333333] rounded-xl py-4 px-4">
+          <div style={{
+            background: "#ffffff",
+            borderTop: "1px solid #808080",
+            borderLeft: "1px solid #808080",
+            borderRight: "1px solid #ffffff",
+            borderBottom: "1px solid #ffffff",
+            padding: "6px 8px",
+          }}>
             <div className="container mx-auto">
               <SearchFilterBar
                 search={search}
@@ -227,17 +248,16 @@ const ProjectsPage = ({ onTabChange, activeTab }: ProjectsPageProps) => {
                 onFilterInteraction={scrollToCards}
               />
 
-              <div className="text-sm text-gray-400 mt-2">
+              <div style={{ fontSize: "10px", color: "#444444", marginTop: "4px" }}>
                 Showing {sortedProjects.length} Project{sortedProjects.length !== 1 ? "s" : ""}
               </div>
             </div>
           </div>
-        </div>
-      </div>
+        </div>{/* end p-4 */}
+      </div>{/* end win-window */}
 
       <div
         id="projects-cards"
-        className="text-white"
         style={{ scrollMarginTop: "calc(var(--navbar-height, 6rem) + 1rem)" }}
       >
         <div className="transition-opacity duration-150 opacity-100 animate-fade-in-up">

--- a/src/app/components/pages/portfolio/ReposPage.tsx
+++ b/src/app/components/pages/portfolio/ReposPage.tsx
@@ -285,12 +285,26 @@ const ReposPage = ({ onTabChange, activeTab }: ReposPageProps) => {
 
   return (
     <>
-      <div id="repos-page-header" className="bg-[#222222] rounded-xl border border-[#333333] p-6 mb-6">
-        <div className="mb-6">
-          <h2 className="text-3xl font-bold text-center mb-4 bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
+      <div
+        id="repos-page-header"
+        className="mb-6"
+        style={{
+          background: "#d4d0c8",
+          borderTop: "2px solid #ffffff",
+          borderLeft: "2px solid #ffffff",
+          borderRight: "2px solid #404040",
+          borderBottom: "2px solid #404040",
+          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+        }}
+      >
+        <div className="win-titlebar">
+          <span style={{ fontSize: "11px" }}>📂 Projects — Repositories</span>
+        </div>
+        <div className="p-4 mb-2">
+          <div style={{ fontSize: "14px", fontWeight: "bold", color: "#000080", textAlign: "center", marginBottom: "8px" }}>
             Projects
-          </h2>
-          <div className="flex justify-center mb-4">
+          </div>
+          <div className="flex justify-center mb-3">
             <PageTabs
               tabs={tabs}
               activeId={activeId}
@@ -298,7 +312,14 @@ const ReposPage = ({ onTabChange, activeTab }: ReposPageProps) => {
             />
           </div>
 
-          <div className="bg-[#1e1e1e] border border-[#333333] rounded-xl py-4 px-4">
+          <div style={{
+            background: "#ffffff",
+            borderTop: "1px solid #808080",
+            borderLeft: "1px solid #808080",
+            borderRight: "1px solid #ffffff",
+            borderBottom: "1px solid #ffffff",
+            padding: "6px 8px",
+          }}>
             <div className="container mx-auto">
               <SearchFilterBar
                 search={search}
@@ -319,31 +340,31 @@ const ReposPage = ({ onTabChange, activeTab }: ReposPageProps) => {
               />
 
               {resultsCount && (
-                <div className="text-sm text-gray-400 mt-2">{resultsCount}</div>
+                <div style={{ fontSize: "10px", color: "#444444", marginTop: "4px" }}>{resultsCount}</div>
               )}
             </div>
           </div>
-        </div>
-      </div>
+        </div>{/* end p-4 */}
+      </div>{/* end win-window */}
       
       <div
         id="repositories-cards"
-        className="text-white"
         style={{ scrollMarginTop: "calc(var(--navbar-height, 6rem) + 1rem)" }}
       >
         <div className="transition-opacity duration-150 opacity-100 animate-fade-in-up">
           {loading ? (
             <ResponsiveCardSkeletonGrid
               renderCard={(i) => (
-                <div
-                  key={i}
-                  className="bg-[#151515] border border-[#333333] p-6 rounded-none animate-pulse flex flex-col gap-4 min-h-[220px]"
-                >
-                  <div className="h-6 bg-[#333333] rounded w-3/4" />
-                  <div className="h-4 bg-[#333333] rounded w-2/3" />
-                  <div className="h-4 bg-[#333333] rounded w-5/6" />
+                <div key={i} className="animate-pulse flex flex-col gap-3 p-3 min-h-[200px]" style={{
+                  background: "#d4d0c8",
+                  borderTop: "1px solid #808080", borderLeft: "1px solid #808080",
+                  borderRight: "1px solid #fff", borderBottom: "1px solid #fff",
+                }}>
+                  <div style={{ height: 12, background: "#c0bdb4", width: "75%" }} />
+                  <div style={{ height: 10, background: "#c0bdb4", width: "66%" }} />
+                  <div style={{ height: 10, background: "#c0bdb4", width: "83%" }} />
                   <div className="flex-1" />
-                  <div className="h-10 bg-[#292929] rounded w-full" />
+                  <div style={{ height: 24, background: "#c0bdb4", width: "100%" }} />
                 </div>
               )}
             />
@@ -357,18 +378,31 @@ const ReposPage = ({ onTabChange, activeTab }: ReposPageProps) => {
                 {tagFilteredProjects.map((project) => (
                     <div
                       key={project.id}
-                      className="group bg-[#151515] hover:bg-[#252525] rounded-none border border-[#333333] hover:border-red-600/50 transition-[background-color,border-color,box-shadow,transform] duration-200 ease-out hover:scale-[1.02] hover:shadow-lg hover:shadow-red-600/30 flex flex-col shrink-0 snap-start min-w-[260px] w-[calc(100%-1.5rem)] sm:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] 2xl:w-[calc((100%-4.5rem)/4)]"
+                      className="group flex flex-col shrink-0 snap-start min-w-[260px] w-[calc(100%-1.5rem)] sm:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] 2xl:w-[calc((100%-4.5rem)/4)]"
+                      style={{
+                        background: "#d4d0c8",
+                        borderTop: "1px solid #ffffff",
+                        borderLeft: "1px solid #ffffff",
+                        borderRight: "1px solid #404040",
+                        borderBottom: "1px solid #404040",
+                        fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+                      }}
                     >
-                       <div className="p-6 flex-grow">
+                      {/* Win2K title bar */}
+                      <div className="win-titlebar" style={{ fontSize: "11px" }}>
+                        <span className="truncate">{project.name}</span>
+                      </div>
+
+                       <div className="p-3 flex-grow">
                          <div className="mb-2">
-                           <h3 className="text-xl font-semibold text-white group-hover:text-[#dc2626] transition-colors duration-300 mb-1 truncate">
+                           <h3 style={{ fontSize: "12px", fontWeight: "bold", color: "#000080", marginBottom: "4px" }} className="truncate">
                              {project.name}
                            </h3>
-                           <div className="flex flex-wrap items-center gap-2">
+                           <div className="flex flex-wrap items-center gap-1">
                              {project.source === "manual" && (
                                <span
                                  onClick={() => handleRepoBadgeClick("manual")}
-                                 className={`${repoBadgeBaseClass} bg-green-600 text-white border border-green-500`}
+                                 style={{ fontSize: "9px", padding: "1px 5px", background: "#008000", color: "#ffffff", cursor: "pointer" }}
                                >
                                  MANUAL
                                </span>
@@ -376,7 +410,7 @@ const ReposPage = ({ onTabChange, activeTab }: ReposPageProps) => {
                              {project.source === "github" && (
                                <span
                                  onClick={() => handleRepoBadgeClick("github")}
-                                 className={`${repoBadgeBaseClass} bg-purple-600 text-white border border-purple-500`}
+                                 style={{ fontSize: "9px", padding: "1px 5px", background: "#800080", color: "#ffffff", cursor: "pointer" }}
                                >
                                  GITHUB
                                </span>
@@ -384,47 +418,55 @@ const ReposPage = ({ onTabChange, activeTab }: ReposPageProps) => {
                              {project.topics.includes("neumont") && (
                                <span
                                  onClick={() => handleRepoBadgeClick("neumont")}
-                                 className={`${repoBadgeBaseClass} bg-yellow-600 text-white border border-yellow-500`}
+                                 style={{ fontSize: "9px", padding: "1px 5px", background: "#808000", color: "#ffffff", cursor: "pointer" }}
                                >
                                  NEU
                                </span>
                              )}
                            </div>
                          </div>
-                         <p className="text-gray-300 mb-2 break-words whitespace-normal">{project.description}</p>
-                         <p className="text-sm text-gray-400 mb-1">
-                           <span className="font-bold">Created On:</span>{" "}
-                           {new Date(project.created_at).toLocaleDateString("en-US", {
-                             year: "numeric",
-                             month: "short",
-                             day: "numeric",
-                           })}
+                         <p className="mb-2 break-words whitespace-normal" style={{ fontSize: "11px", color: "#000000" }}>{project.description}</p>
+                         <p style={{ fontSize: "10px", color: "#444444", marginBottom: "2px" }}>
+                           <span style={{ fontWeight: "bold" }}>Created:</span>{" "}
+                           {new Date(project.created_at).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
                          </p>
-                         <p className="text-sm text-gray-400 mb-2">
-                           <span className="font-bold">Last Updated:</span>{" "}
-                           {new Date(project.updated_at).toLocaleDateString("en-US", {
-                             year: "numeric",
-                             month: "short",
-                             day: "numeric",
-                           })}
+                         <p style={{ fontSize: "10px", color: "#444444", marginBottom: "6px" }}>
+                           <span style={{ fontWeight: "bold" }}>Updated:</span>{" "}
+                           {new Date(project.updated_at).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
                          </p>
-                         <div className="flex flex-wrap gap-1.5 sm:gap-2 mt-3">
+                         <div className="flex flex-wrap gap-1 mt-2">
                            {[...new Set([...project.topics, project.language].filter(Boolean).map((t) => t.toLowerCase()))].map((tag) => (
                              <span
                                key={tag}
                                onClick={() => handleTagClick(tag)}
-                               className="bg-[#3a3a3a] text-gray-300 text-xs px-3 py-1 rounded-full whitespace-nowrap max-w-full min-w-0 truncate transition-all duration-200 border border-transparent hover:bg-[#444444] hover:scale-105 hover:shadow-lg hover:shadow-red-600/30 hover:border-red-600 hover:text-[#dc2626] cursor-pointer active:scale-95"
+                               style={{
+                                 fontSize: "9px",
+                                 padding: "1px 5px",
+                                 background: "#c0bdb4",
+                                 color: "#000000",
+                                 borderTop: "1px solid #808080",
+                                 borderLeft: "1px solid #808080",
+                                 borderRight: "1px solid #ffffff",
+                                 borderBottom: "1px solid #ffffff",
+                                 cursor: "pointer",
+                                 whiteSpace: "nowrap",
+                               }}
                              >
                                {tag.toUpperCase()}
                              </span>
                            ))}
                          </div>
                        </div>
-                       <div className="px-6 py-4 border-t border-[#333333] bg-[#151515]">
+                       <div style={{
+                         padding: "6px 8px",
+                         borderTop: "1px solid #808080",
+                         background: "#c8c5bc",
+                       }}>
                          <TooltipWrapper label={project.html_url} fullWidth>
                            <button
                              onClick={() => handleExternalClick(project.html_url, true)}
-                             className="flex items-center justify-center gap-2 w-full p-3 min-h-[48px] bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-white rounded-lg transition-all duration-200 ease-out hover:scale-105 active:scale-95 text-sm sm:text-base"
+                             className="win-btn flex items-center justify-center gap-2 w-full"
+                             style={{ fontSize: "11px", padding: "4px 8px" }}
                            >
                              {getCTAIcon(project.ctaIcon ?? (project.source === "github" ? "github" : undefined))}
                              <span className="flex-1 break-words text-center leading-tight">

--- a/src/app/components/pages/sidebar/Sidebar.tsx
+++ b/src/app/components/pages/sidebar/Sidebar.tsx
@@ -19,66 +19,127 @@ const Sidebar = ({ className = "" }: { className?: string }) => {
 
   return (
     <>
-      <aside className={`w-full lg:w-80 bg-[#222222] rounded-xl border border-[#333333] shadow-lg p-6 self-start relative z-10 lg:sticky lg:top-2 my-8 ${className}`}>
+      {/* Win2K window panel */}
+      <aside
+        className={`w-full lg:w-72 self-start relative z-10 lg:sticky lg:top-2 my-4 ${className}`}
+        style={{
+          background: "#d4d0c8",
+          borderTop: "2px solid #ffffff",
+          borderLeft: "2px solid #ffffff",
+          borderRight: "2px solid #404040",
+          borderBottom: "2px solid #404040",
+          fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+        }}
+      >
         <audio ref={clickSoundRef} src="/sounds/yippe.mp3" preload="auto" />
 
-        {/* Avatar */}
-        <div
-          className="relative w-32 h-32 mx-auto rounded-full overflow-hidden group cursor-pointer transition-transform duration-300 ease-out hover:scale-105 active:scale-100"
-          onClick={handleAvatarClick}
-        >
-          <div className="absolute -inset-0.5 rounded-full opacity-0 blur-sm transition duration-300 group-hover:opacity-5 group-hover:bg-gradient-to-r group-hover:from-red-700 group-hover:to-red-500"></div>
-          <Avatar />
-        </div>
-
-        <div className="mt-4 text-center">
-          <h2 className="text-2xl font-bold bg-gradient-to-r from-red-600 to-red-500 bg-clip-text text-transparent">
-            Ethan Townsend
-          </h2>
-          <p className="text-gray-300">Full Stack Software Developer</p>
-          <p className="text-gray-400 text-sm mt-1">Salt Lake City, UT</p>
-        </div>
-
-        {/* View Resume Button */}
-        <div className="mt-6 flex justify-center">
-          <TooltipWrapper label="View Resume" url="/resume/EthanTownsend_Resume_march2026.pdf">
-            <button
-              onClick={() => setSelectedPDF('/resume/EthanTownsend_Resume_march2026.pdf')}
-              aria-label="View Resume"
-              className="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-white rounded-lg transition-all duration-200 ease-out hover:scale-105 active:scale-95 text-sm font-medium shadow-lg shadow-red-600/40"
-            >
-              <FaFilePdf />
-              <span>View Resume</span>
-            </button>
-          </TooltipWrapper>
-        </div>
-
-        {/* Professional Links */}
-        <div className="mt-6">
-          <div className="w-full h-px bg-gradient-to-r from-transparent via-[#333333] to-transparent"></div>
-          <div className="flex justify-center space-x-6 mt-4">
-            {socialLinks.professional.map(({ label, icon, url, tooltip }) => {
-              const Icon = Icons[icon as keyof typeof Icons]
-              return (
-                <TooltipWrapper key={label} label={tooltip}>
-                  <a
-                    href={url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={label}
-                    className="text-gray-300 hover:text-red-600 text-2xl transition-all duration-200 ease-out hover:scale-125 active:scale-100"
-                  >
-                    <Icon />
-                  </a>
-                </TooltipWrapper>
-              )
-            })}
+        {/* Window title bar */}
+        <div className="win-titlebar">
+          <span style={{ fontSize: "11px" }}>👤 User Profile</span>
+          <div className="ml-auto flex gap-1">
+            <div style={{
+              background: "#d4d0c8", borderTop: "1px solid #fff", borderLeft: "1px solid #fff",
+              borderRight: "1px solid #404040", borderBottom: "1px solid #404040",
+              width: "16px", height: "14px", fontSize: "9px", display: "flex",
+              alignItems: "center", justifyContent: "center", color: "#000",
+            }}>─</div>
+            <div style={{
+              background: "#d4d0c8", borderTop: "1px solid #fff", borderLeft: "1px solid #fff",
+              borderRight: "1px solid #404040", borderBottom: "1px solid #404040",
+              width: "16px", height: "14px", fontSize: "9px", display: "flex",
+              alignItems: "center", justifyContent: "center", color: "#000",
+            }}>□</div>
           </div>
         </div>
 
-        {/* Spotify Widget */}
-        <div className="mt-6">
-          <SpotifyWidget />
+        {/* Content area */}
+        <div className="p-4">
+          {/* Avatar */}
+          <div
+            className="relative w-28 h-28 mx-auto overflow-hidden cursor-pointer"
+            style={{
+              borderTop: "2px solid #808080",
+              borderLeft: "2px solid #808080",
+              borderRight: "2px solid #ffffff",
+              borderBottom: "2px solid #ffffff",
+            }}
+            onClick={handleAvatarClick}
+          >
+            <Avatar />
+          </div>
+
+          {/* Name & Title */}
+          <div className="mt-3 text-center">
+            <h2 style={{ fontSize: "13px", fontWeight: "bold", color: "#000080" }}>
+              Ethan Townsend
+            </h2>
+            <p style={{ fontSize: "11px", color: "#444444", marginTop: "2px" }}>Full Stack Software Developer</p>
+            <p style={{ fontSize: "10px", color: "#666666", marginTop: "1px" }}>Salt Lake City, UT</p>
+          </div>
+
+          {/* Horizontal separator */}
+          <div style={{ marginTop: "10px", marginBottom: "10px", borderTop: "1px solid #808080", borderBottom: "1px solid #ffffff" }} />
+
+          {/* View Resume Button */}
+          <div className="flex justify-center">
+            <TooltipWrapper label="View Resume" url="/resume/EthanTownsend_Resume_march2026.pdf">
+              <button
+                onClick={() => setSelectedPDF('/resume/EthanTownsend_Resume_march2026.pdf')}
+                aria-label="View Resume"
+                className="win-btn flex items-center gap-1.5"
+                style={{ fontSize: "11px", padding: "3px 12px" }}
+              >
+                <FaFilePdf style={{ fontSize: "12px" }} />
+                <span>View Resume</span>
+              </button>
+            </TooltipWrapper>
+          </div>
+
+          {/* Horizontal separator */}
+          <div style={{ marginTop: "10px", marginBottom: "10px", borderTop: "1px solid #808080", borderBottom: "1px solid #ffffff" }} />
+
+          {/* Professional Links */}
+          <div>
+            <p style={{ fontSize: "10px", fontWeight: "bold", color: "#000000", marginBottom: "6px", textAlign: "center" }}>
+              Links:
+            </p>
+            <div className="flex justify-center gap-4">
+              {socialLinks.professional.map(({ label, icon, url, tooltip }) => {
+                const Icon = Icons[icon as keyof typeof Icons]
+                return (
+                  <TooltipWrapper key={label} label={tooltip}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={label}
+                      className="flex items-center justify-center"
+                      style={{
+                        background: "#d4d0c8",
+                        borderTop: "1px solid #fff",
+                        borderLeft: "1px solid #fff",
+                        borderRight: "1px solid #404040",
+                        borderBottom: "1px solid #404040",
+                        width: "28px", height: "28px",
+                        fontSize: "14px",
+                        color: "#000080",
+                        cursor: "pointer",
+                      }}
+                      onMouseEnter={e => (e.currentTarget.style.background = "#c0bdb4")}
+                      onMouseLeave={e => (e.currentTarget.style.background = "#d4d0c8")}
+                    >
+                      <Icon />
+                    </a>
+                  </TooltipWrapper>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Spotify Widget */}
+          <div className="mt-3">
+            <SpotifyWidget />
+          </div>
         </div>
       </aside>
 

--- a/src/app/components/pages/sidebar/SpotifyWidget.tsx
+++ b/src/app/components/pages/sidebar/SpotifyWidget.tsx
@@ -93,70 +93,75 @@ export default function SpotifyWidget() {
 
   if (!isVisible && !isAnimatingOut) return null // If the widget is not visible and not animating out, return null
 
-  // This is the main container for the widget. It has a dark background, rounded corners, and a shadow effect.
-  const containerClasses = `bg-[#222222] border border-[#333333] rounded-xl p-4 shadow-md ${
-    loading ? "animate-pulse animate-elastic-in" :
-    isAnimatingOut ? "animate-elastic-out" :
-    "animate-elastic-in"
-  }`
+  const containerClasses = isAnimatingOut ? "animate-elastic-out" : "animate-elastic-in"
 
-  // The container has a gradient background and a shadow effect when the track is playing.
   return (
-  <div className={`${containerClasses} max-w-md mx-auto`}>
-      {/* Loading state: Show a skeleton loader while the track is loading */}
+    <div
+      className={`${containerClasses} max-w-md mx-auto`}
+      style={{
+        background: "#d4d0c8",
+        borderTop: "1px solid #ffffff",
+        borderLeft: "1px solid #ffffff",
+        borderRight: "1px solid #404040",
+        borderBottom: "1px solid #404040",
+        fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+      }}
+    >
+      {/* Win2K group box title */}
+      <div className="win-titlebar" style={{ fontSize: "10px", padding: "2px 4px" }}>
+        <FaSpotify style={{ fontSize: "10px" }} />
+        <span>Now Listening</span>
+      </div>
+
       {loading ? (
-        <>
-          <div className="flex justify-center items-center gap-2 mb-2">
-            <div className="w-5 h-5 bg-[#333333] rounded-full" />
-            <span className="h-4 bg-[#333333] w-24 rounded"></span>
+        <div className="p-2 animate-pulse flex items-center gap-2">
+          <div style={{ width: 36, height: 36, background: "#c0bdb4", borderTop: "1px solid #808080", borderLeft: "1px solid #808080", borderRight: "1px solid #fff", borderBottom: "1px solid #fff" }} />
+          <div className="flex flex-col gap-1.5 flex-1">
+            <div style={{ height: "10px", background: "#c0bdb4", borderRadius: 0 }} />
+            <div style={{ height: "9px", background: "#c0bdb4", borderRadius: 0, width: "70%" }} />
           </div>
-          <div className="flex items-center justify-center gap-4 p-2">
-            <div className="w-12 h-12 bg-[#333333] rounded"></div>
-            <div className="flex flex-col gap-2 w-3/5">
-              <div className="h-4 bg-[#333333] rounded w-full"></div>
-              <div className="h-3 bg-[#333333] rounded w-3/4"></div>
-            </div>
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="flex items-center justify-center gap-2 mb-2">
-          <TooltipWrapper label="My Spotify Profile">
-            <button
-              onClick={() =>
-                handleExternalClick("https://open.spotify.com/user/l7ypevjdnoaz97kdqkkwf832d")
-              }
-              aria-label="Spotify"
-              className="text-gray-400 hover:text-red-600 text-lg flex items-center transition-transform duration-200 ease-out hover:scale-125 active:scale-100"
-            >
-              <FaSpotify />
-            </button>
-          </TooltipWrapper>
-          <span className="text-sm leading-none text-gray-400">now listening:</span>
         </div>
-        <div className="flex items-center justify-center">
-          <TooltipWrapper label={track!.songUrl}> {/* Tooltip to show the song URL */}
+      ) : (
+        <div className="p-2">
+          <TooltipWrapper label={track!.songUrl}>
             <button
               onClick={() => handleExternalClick(track!.songUrl)}
-              className="relative flex items-center justify-center gap-4 p-2 rounded-lg transition group w-full"
+              className="flex items-center gap-2 w-full text-left"
+              style={{ background: "transparent", border: "none", cursor: "pointer" }}
+              onMouseEnter={e => (e.currentTarget.style.background = "#c0bdb4")}
+              onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
             >
               <Image
                 src={track!.albumImageUrl}
                 alt="Album Art"
-                width={48}
-                height={48}
-                className="w-12 h-12 rounded object-cover border border-[#333333]"
+                width={36}
+                height={36}
+                style={{
+                  width: 36, height: 36, objectFit: "cover",
+                  borderTop: "1px solid #808080", borderLeft: "1px solid #808080",
+                  borderRight: "1px solid #fff", borderBottom: "1px solid #fff",
+                }}
               />
-              <div className="text-left">
-                <p className="text-white font-semibold leading-tight">{track!.title}</p>
-                <p className="text-gray-400 text-sm">{track!.artist}</p>
+              <div className="text-left overflow-hidden">
+                <p style={{ fontSize: "11px", fontWeight: "bold", color: "#000000", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{track!.title}</p>
+                <p style={{ fontSize: "10px", color: "#444444", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{track!.artist}</p>
               </div>
-              <div className="absolute -inset-0.5 rounded-lg opacity-10 blur-sm transition duration-300 group-hover:opacity-10 group-hover:bg-gradient-to-r group-hover:from-red-700 group-hover:to-red-500 z-0"></div>
             </button>
           </TooltipWrapper>
-                  </div>
-
-        </>
+          <div className="mt-1 flex justify-end">
+            <TooltipWrapper label="My Spotify Profile">
+              <button
+                onClick={() => handleExternalClick("https://open.spotify.com/user/l7ypevjdnoaz97kdqkkwf832d")}
+                aria-label="Spotify"
+                className="win-btn flex items-center gap-1"
+                style={{ fontSize: "9px", padding: "1px 5px", minWidth: "auto" }}
+              >
+                <FaSpotify style={{ fontSize: "9px" }} />
+                <span>Open</span>
+              </button>
+            </TooltipWrapper>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,31 +1,343 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+  /* Windows 2000 color palette */
+  --win-silver: #d4d0c8;
+  --win-silver-dark: #c0c0c0;
+  --win-silver-darker: #808080;
+  --win-silver-light: #ece9d8;
+  --win-silver-lighter: #f0ede6;
+  --win-titlebar-start: #0a246a;
+  --win-titlebar-end: #a6caf0;
+  --win-active-title: #0a246a;
+  --win-navy: #000080;
+  --win-text: #000000;
+  --win-white: #ffffff;
+  --win-button-face: #d4d0c8;
+  --win-button-highlight: #ffffff;
+  --win-button-shadow: #808080;
+  --win-button-dark-shadow: #404040;
+  --win-border-light: #ffffff;
+  --win-border-dark: #808080;
 
-:root {
+  --background: var(--win-silver-light);
+  --foreground: var(--win-text);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #222222;
-    --foreground: #ededed;
-  }
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
-  overflow-x: hidden;  /* Keep page width bounded; use local scrollers instead */
-  min-width: 360px;    /* Prevent UI from condensing below 360px */
+  background: var(--win-silver-light);
+  color: var(--win-text);
+  font-family: "Tahoma", "MS Sans Serif", Arial, sans-serif;
+  overflow-x: hidden;
+  min-width: 360px;
 }
+
+/* Windows 2000 raised border (button look) */
+.win-raised {
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-button-dark-shadow);
+  background-color: var(--win-button-face);
+}
+.win-raised-outer {
+  border-style: solid;
+  border-width: 2px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-button-dark-shadow);
+}
+
+/* Windows 2000 sunken border (inset/field look) */
+.win-sunken {
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: var(--win-button-shadow);
+  border-left-color: var(--win-button-shadow);
+  border-right-color: var(--win-button-highlight);
+  border-bottom-color: var(--win-button-highlight);
+  background-color: var(--win-white);
+}
+
+/* Win2K window chrome */
+.win-window {
+  background-color: var(--win-silver);
+  border-style: solid;
+  border-width: 2px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-button-dark-shadow);
+}
+
+/* Win2K title bar */
+.win-titlebar {
+  background: linear-gradient(to right, var(--win-titlebar-start), var(--win-titlebar-end));
+  color: white;
+  font-weight: bold;
+  font-size: 12px;
+  padding: 3px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+
+/* Win2K button */
+.win-btn {
+  background-color: var(--win-button-face);
+  color: var(--win-text);
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-button-dark-shadow);
+  padding: 2px 8px;
+  font-family: "Tahoma", "MS Sans Serif", Arial, sans-serif;
+  font-size: 11px;
+  cursor: pointer;
+  min-width: 75px;
+}
+.win-btn:hover {
+  background-color: #e0ddd5;
+}
+.win-btn:active,
+.win-btn-active {
+  border-top-color: var(--win-button-dark-shadow);
+  border-left-color: var(--win-button-dark-shadow);
+  border-right-color: var(--win-button-highlight);
+  border-bottom-color: var(--win-button-highlight);
+}
+
+/* Win2K tab (active & inactive) */
+.win-tab-active {
+  background-color: var(--win-silver);
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-silver); /* blends with panel below */
+  padding: 3px 10px 4px;
+  font-size: 11px;
+  font-family: "Tahoma", "MS Sans Serif", Arial, sans-serif;
+  position: relative;
+  z-index: 1;
+  margin-bottom: -1px;
+  cursor: default;
+}
+.win-tab-inactive {
+  background-color: #bab8b0;
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-button-shadow);
+  padding: 2px 10px 3px;
+  font-size: 11px;
+  font-family: "Tahoma", "MS Sans Serif", Arial, sans-serif;
+  cursor: pointer;
+  margin-top: 2px;
+}
+.win-tab-inactive:hover {
+  background-color: #ccc9c0;
+}
+
+/* Ensure clickable elements use pointer cursor */
+button:not(:disabled):hover,
+a[href]:hover,
+[role="button"]:hover {
+  cursor: pointer;
+}
+button:disabled {
+  cursor: not-allowed;
+}
+
+/* Win2K scrollbar */
+::-webkit-scrollbar {
+  width: 16px;
+  height: 16px;
+}
+::-webkit-scrollbar-track {
+  background: var(--win-silver);
+  border-left: 1px solid var(--win-button-shadow);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--win-button-face);
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-button-dark-shadow);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #c5c2ba;
+}
+::-webkit-scrollbar-button {
+  background: var(--win-button-face);
+  border-style: solid;
+  border-width: 1px;
+  border-top-color: var(--win-button-highlight);
+  border-left-color: var(--win-button-highlight);
+  border-right-color: var(--win-button-dark-shadow);
+  border-bottom-color: var(--win-button-dark-shadow);
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+::-webkit-scrollbar-corner {
+  background: var(--win-silver);
+}
+* {
+  scrollbar-width: auto;
+  scrollbar-color: var(--win-button-face) var(--win-silver);
+}
+
+.footer-links {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-height: 124px) {
+  .footer-links {
+    flex-direction: column;
+  }
+}
+
+/* Win2K taskbar at bottom */
+.win-taskbar {
+  background: linear-gradient(to bottom, #d4d0c8, #c0bdb4);
+  border-top: 2px solid #ffffff;
+  font-family: "Tahoma", "MS Sans Serif", Arial, sans-serif;
+  font-size: 11px;
+}
+
+/* Animation (kept for functional dropdowns) */
+@keyframes fadeInScale {
+  0% { opacity: 0; transform: scale(0.95); }
+  100% { opacity: 1; transform: scale(1); }
+}
+.animate-fadeInScale {
+  animation: fadeInScale 0.15s ease-out forwards;
+}
+
+@keyframes fade-in-up {
+  0% { opacity: 0; transform: translateY(8px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+.animate-fade-in-up {
+  animation: fade-in-up 0.2s ease-out forwards;
+}
+
+@keyframes fade-out-down {
+  0% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-8px); }
+}
+.animate-fade-out-down {
+  animation: fade-out-down 0.15s ease-in forwards;
+}
+
+@keyframes elastic-in {
+  0% { opacity: 0; transform: scaleX(0.6) scaleY(1.4); }
+  50% { transform: scaleX(1.1) scaleY(0.9); }
+  100% { opacity: 1; transform: scale(1); }
+}
+.animate-elastic-in { animation: elastic-in 0.3s ease-out forwards; }
+
+@keyframes elastic-out {
+  0% { opacity: 1; transform: scale(1); }
+  50% { transform: scaleX(1.1) scaleY(0.9); }
+  100% { opacity: 0; transform: scaleX(0.6) scaleY(1.4); }
+}
+.animate-elastic-out { animation: elastic-out 0.25s ease-in forwards; }
+
+@keyframes zoom-rotate {
+  from { opacity: 0; transform: scale(0.7) rotate(-5deg); }
+  to { opacity: 1; transform: scale(1) rotate(0deg); }
+}
+.animate-zoom-rotate { animation: zoom-rotate 0.3s ease-out forwards; }
+
+@keyframes elastic-light {
+  0% { opacity: 0; transform: scale(0.97); }
+  100% { opacity: 1; transform: scale(1); }
+}
+.animate-elastic-light { animation: elastic-light 0.3s ease-out forwards; }
+
+@keyframes tag-extend {
+  0% { opacity: 0; transform: scale(0.8) translateY(-10px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+.animate-tag-extend { animation: tag-extend 0.3s ease-out forwards; }
+
+@keyframes tag-hide {
+  0% { opacity: 1; transform: scale(1) translateY(0); }
+  100% { opacity: 0; transform: scale(0.8) translateY(-10px); }
+}
+.animate-tag-hide { animation: tag-hide 0.2s ease-in forwards; }
+
+@keyframes fade-out-down {
+  0% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-20px); }
+}
+
+@keyframes popIn {
+  0% { opacity: 0; transform: scale(0.9) translateY(-6px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+@keyframes popOut {
+  0% { opacity: 1; transform: scale(1) translateY(0); }
+  100% { opacity: 0; transform: scale(0.9) translateY(-6px); }
+}
+.animate-popIn { animation: popIn 0.15s ease-out forwards; }
+
+/* Navbar horizontal scroll */
+.navbar-scroll::-webkit-scrollbar { height: 6px; }
+.navbar-scroll::-webkit-scrollbar-track { background: transparent; }
+.navbar-scroll::-webkit-scrollbar-thumb { background: #808080; }
+
+@media (min-width: 768px) {
+  .navbar-scroll::-webkit-scrollbar { display: none; }
+}
+@media (max-width: 767px) {
+  .navbar-scroll { scrollbar-width: thin; scrollbar-color: #808080 transparent; }
+}
+
+.marquee { overflow: hidden; position: relative; width: 100%; }
+.marquee-track {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: max-content;
+  animation: marquee-scroll 30s linear infinite;
+}
+.marquee-track.slower { animation-duration: 40s; }
+@keyframes marquee-scroll {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track { animation: none; }
+}
+
+@keyframes pin-bounce {
+  0% { transform: translateY(0); }
+  35% { transform: translateY(-6px); }
+  70% { transform: translateY(0); }
+  85% { transform: translateY(-3px); }
+  100% { transform: translateY(0); }
+}
+.animate-pin-bounce { animation: pin-bounce 0.38s ease-out; }
 
 /* Ensure clickable elements use the pointer cursor on hover. */
 button:not(:disabled):hover,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -84,8 +84,8 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="dark">
-      <body suppressHydrationWarning className="bg-[#1a1a1a] text-white font-sans">
+    <html lang="en">
+      <body suppressHydrationWarning className="font-sans" style={{ background: "#ece9d8", color: "#000000" }}>
         <Script
           id="person-jsonld"
           type="application/ld+json"
@@ -95,52 +95,38 @@ export default function RootLayout({
         <Toaster 
           position="top-center"
           toastOptions={{
-            // Default options for all toasts
             duration: 4000,
             className: 'animate-fade-in-up',
             style: {
-              background: '#1e1e1e',
-              color: '#fff',
-              border: '1px solid #333333',
-              borderRadius: '0.75rem',
-              padding: '16px',
-              fontSize: '14px',
-              boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.3)',
+              background: '#d4d0c8',
+              color: '#000000',
+              border: '1px solid',
+              borderTopColor: '#ffffff',
+              borderLeftColor: '#ffffff',
+              borderRightColor: '#404040',
+              borderBottomColor: '#404040',
+              borderRadius: '0',
+              padding: '8px 12px',
+              fontSize: '11px',
+              fontFamily: '"Tahoma", "MS Sans Serif", Arial, sans-serif',
+              boxShadow: '2px 2px 4px rgba(0,0,0,0.4)',
             },
-            // Success toast styling
             success: {
               duration: 3000,
               className: 'animate-fade-in-up',
-              style: {
-                border: '1px solid #10b981',
-              },
-              iconTheme: {
-                primary: '#10b981',
-                secondary: '#1e1e1e',
-              },
+              style: { borderTopColor: '#008000' },
+              iconTheme: { primary: '#008000', secondary: '#d4d0c8' },
             },
-            // Error toast styling
             error: {
               duration: 4000,
               className: 'animate-fade-in-up',
-              style: {
-                border: '1px solid #dc2626',
-              },
-              iconTheme: {
-                primary: '#dc2626',
-                secondary: '#1e1e1e',
-              },
+              style: { borderTopColor: '#800000' },
+              iconTheme: { primary: '#800000', secondary: '#d4d0c8' },
             },
-            // Loading toast styling
             loading: {
               className: 'animate-fade-in-up',
-              style: {
-                border: '1px solid #ef4444',
-              },
-              iconTheme: {
-                primary: '#ef4444',
-                secondary: '#1e1e1e',
-              },
+              style: {},
+              iconTheme: { primary: '#000080', secondary: '#d4d0c8' },
             },
           }}
         />


### PR DESCRIPTION
## Windows 2000 Redesign

Converts the entire portfolio site from the dark red/charcoal aesthetic to a faithful Windows 2000 / Windows XP Classic theme.

### Changes

**globals.css**
- Replaced dark theme variables with Win2K silver palette (`#d4d0c8`, `#c0bdb4`, `#ece9d8`)
- Added utility classes: `.win-raised`, `.win-sunken`, `.win-window`, `.win-titlebar`, `.win-btn`, `.win-tab-active`, `.win-tab-inactive`
- Replaced red gradient scrollbars with classic Win2K chunky gray scrollbars with raised button chrome
- Set default font to `Tahoma / MS Sans Serif`

**layout.tsx** — removed `dark` class, switched body to silver background

**Navbar.tsx** — Win2K title bar strip with navy gradient, raised border buttons with pressed-in state

**Sidebar.tsx** — Win2K window chrome with title bar, sunken avatar frame, icon link buttons

**SpotifyWidget.tsx** — Win2K group-box panel with title bar and classic button

**PageTabs.tsx** — Win2K tab strip with active/inactive 3D border tab look

**About.tsx / ExperiencePage.tsx / EducationPage.tsx / ProjectsPage.tsx / ReposPage.tsx** — all section containers converted to Win2K window panels with title bars, sunken search fields, classic button actions

**SearchFilterBar.tsx** — sunken input field, raised Filter/Sort buttons, Win2K dropdown menu with navy highlight rows

**Timeline.tsx** — timeline cards use Win2K window chrome with raised borders, navy title bars, classic badge styles

**ReposPage.tsx** — repo cards with Win2K window chrome and classic raised CTA buttons

**Footer.tsx** — Win2K taskbar style with gradient silver background and raised icon buttons

**ToolTipWrapper.tsx** — tooltips use Win2K panel chrome with title bars

**SectionScrollRail.tsx** — scroll rail markers use Win2K raised/active button style